### PR TITLE
optimize datadog backend

### DIFF
--- a/datadog/tag.go
+++ b/datadog/tag.go
@@ -1,1 +1,0 @@
-package datadog

--- a/iostats/format.go
+++ b/iostats/format.go
@@ -1,0 +1,136 @@
+package iostats
+
+import (
+	"strconv"
+	"sync"
+	"unicode/utf8"
+)
+
+// A Formatter exposes a couple of optimized routines for formatting values to
+// different representations. It maintains an internal buffer to reuse memory in
+// an efficient way.
+//
+// Formatter buffers are also allocated from memory pools to avoid re-allocation
+// of memory buffers as much as possible.
+//
+// The zero-value of a formatter is a valid value, buffers are lazy-allocated on
+// demand when the formatter is used.
+//
+// Formatters are not safe to use concurrently from multiple goroutines.
+type Formatter struct {
+	b []byte            // general purpose buffer
+	r [utf8.UTFMax]byte // rune buffer
+}
+
+// Release puts the formatter's internal buffer pack into the internal memory
+// pool.
+func (f *Formatter) Release() {
+	b := f.b
+	f.b = nil
+	formatterPool.Put(b)
+}
+
+// FormatBool calls strconv.FormatBool using the formatter's internal buffer
+// then returns the formatted value.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatBool(v bool) []byte {
+	f.b = strconv.AppendBool(f.buffer(), v)
+	return f.b
+}
+
+// FormatInt calls strconv.FormatInt using the formatter's internal buffer
+// then returns the formatted value.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatInt(v int64, base int) []byte {
+	f.b = strconv.AppendInt(f.buffer(), v, base)
+	return f.b
+}
+
+// FormatUint calls strconv.FormatUint using the formatter's internal buffer
+// then returns the formatted value.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatUint(v uint64, base int) []byte {
+	f.b = strconv.AppendUint(f.buffer(), v, base)
+	return f.b
+}
+
+// FormatFloat calls strconv.FormatFloat using the formatter's internal
+// buffer then returns the formatted value.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatFloat(v float64, format byte, precision int, bitSize int) []byte {
+	f.b = strconv.AppendFloat(f.buffer(), v, format, precision, bitSize)
+	return f.b
+}
+
+// FormatByte converts a byte to a byte slice using the formatter's internal
+// memory buffer.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatByte(b byte) []byte {
+	f.b = append(f.buffer(), b)
+	return f.b
+}
+
+// FormatRune converts a rune to a byte slice using the formatter's internal
+// memory buffer.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatRune(r rune) []byte {
+	n := utf8.EncodeRune(f.r[:], r)
+	f.b = append(f.buffer(), f.r[:n]...)
+	return f.b
+}
+
+// FormatString converts a string to a byte slice using the formatter's internal
+// memory buffer.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatString(s string) []byte {
+	f.b = append(f.buffer(), s...)
+	return f.b
+}
+
+// FormatString converts a string to a byte slice using the formatter's internal
+// memory buffer, applying t to each rune of the string.
+//
+// The returned byte slice is value until the next call to a formatter's
+// method.
+func (f *Formatter) FormatStringFunc(s string, t func(rune) rune) []byte {
+	b := f.buffer()
+
+	for _, r := range s {
+		n := utf8.EncodeRune(f.r[:], t(r))
+		b = append(b, f.r[:n]...)
+	}
+
+	f.b = b
+	return b
+}
+
+func (f *Formatter) buffer() []byte {
+	if f.b == nil {
+		f.b = formatterPool.Get().([]byte)
+	}
+	return f.b[:0]
+}
+
+const (
+	defaultFormatterBufferCapacity = 512
+)
+
+var (
+	formatterPool = sync.Pool{
+		New: func() interface{} { return make([]byte, 0, defaultFormatterBufferCapacity) },
+	}
+)

--- a/iostats/format_test.go
+++ b/iostats/format_test.go
@@ -1,0 +1,206 @@
+package iostats
+
+import (
+	"testing"
+	"unicode"
+)
+
+func TestFormatBool(t *testing.T) {
+	tests := []struct {
+		v bool
+		s string
+	}{
+		{
+			v: false,
+			s: "false",
+		},
+		{
+			v: true,
+			s: "true",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatBool(test.v)); s != test.s {
+			t.Errorf("FormatBool: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatInt(t *testing.T) {
+	tests := []struct {
+		v int64
+		s string
+	}{
+		{
+			v: 0,
+			s: "0",
+		},
+		{
+			v: 42,
+			s: "42",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatInt(test.v, 10)); s != test.s {
+			t.Errorf("FormatInt: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatUint(t *testing.T) {
+	tests := []struct {
+		v uint64
+		s string
+	}{
+		{
+			v: 0,
+			s: "0",
+		},
+		{
+			v: 42,
+			s: "42",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatUint(test.v, 10)); s != test.s {
+			t.Errorf("FormatUint: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatFloat(t *testing.T) {
+	tests := []struct {
+		v float64
+		s string
+	}{
+		{
+			v: 0,
+			s: "0",
+		},
+		{
+			v: 1.234,
+			s: "1.234",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatFloat(test.v, 'g', -1, 64)); s != test.s {
+			t.Errorf("FormatFloat: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatByte(t *testing.T) {
+	tests := []struct {
+		v byte
+		s string
+	}{
+		{
+			v: '0',
+			s: "0",
+		},
+		{
+			v: 'A',
+			s: "A",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatByte(test.v)); s != test.s {
+			t.Errorf("FormatByte: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatRune(t *testing.T) {
+	tests := []struct {
+		v rune
+		s string
+	}{
+		{
+			v: '0',
+			s: "0",
+		},
+		{
+			v: 'A',
+			s: "A",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatRune(test.v)); s != test.s {
+			t.Errorf("FormatRune: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatString(t *testing.T) {
+	tests := []struct {
+		v string
+		s string
+	}{
+		{
+			v: "",
+			s: "",
+		},
+		{
+			v: "Hello World!",
+			s: "Hello World!",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatString(test.v)); s != test.s {
+			t.Errorf("FormatString: %#v != %#v", test.s, s)
+		}
+	}
+}
+
+func TestFormatStringFunc(t *testing.T) {
+	tests := []struct {
+		v string
+		s string
+	}{
+		{
+			v: "",
+			s: "",
+		},
+		{
+			v: "Hello World!",
+			s: "hello world!",
+		},
+	}
+
+	f := Formatter{}
+	defer f.Release()
+
+	for _, test := range tests {
+		if s := string(f.FormatStringFunc(test.v, unicode.ToLower)); s != test.s {
+			t.Errorf("FormatString: %#v != %#v", test.s, s)
+		}
+	}
+}


### PR DESCRIPTION
@f2prateek since I think you're the only one with some context on this repo you're on review duty 💃 

I've noticed that this library was causing huge GC work on a service that depends on it so I spent a bit of time digging into the root cause.

This is the first part of the fix, the datadog serialization code was causing huge amounts of memory allocations and was on a pretty busy path.

Please take a look and let me know what you think about it.