### PR TITLE
optimize metrics

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,11 +22,11 @@ func TestClient(t *testing.T) {
 	m3 := c.Histogram("events.seconds")
 	m4 := c.Timer("events.seconds").Start()
 
-	m1.Set(1)
-	m1.Set(42)
-	m2.Add(10)
-	m1.Set(0)
-	m3.Observe(1)
+	m1.Set(1, Tag{"question", "answer"})
+	m1.Set(42, Tag{"question", "answer"})
+	m2.Add(10, Tag{"question", "answer"})
+	m1.Set(0, Tag{"question", "answer"})
+	m3.Observe(1, Tag{"question", "answer"})
 
 	m4.StampAt("a", now.Add(1*time.Second))
 	m4.StampAt("b", now.Add(2*time.Second))
@@ -44,7 +44,7 @@ func TestClient(t *testing.T) {
 			Name:   "test.events.quantity",
 			Value:  1,
 			Sample: 1,
-			Tags:   Tags{{"hello", "world"}},
+			Tags:   Tags{{"hello", "world"}, {"question", "answer"}},
 			Time:   now,
 		},
 		{
@@ -52,7 +52,7 @@ func TestClient(t *testing.T) {
 			Name:   "test.events.quantity",
 			Value:  42,
 			Sample: 1,
-			Tags:   Tags{{"hello", "world"}},
+			Tags:   Tags{{"hello", "world"}, {"question", "answer"}},
 			Time:   now,
 		},
 		{
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 			Name:   "test.events.count",
 			Value:  10,
 			Sample: 1,
-			Tags:   Tags{{"hello", "world"}, {"extra", "tag"}},
+			Tags:   Tags{{"hello", "world"}, {"extra", "tag"}, {"question", "answer"}},
 			Time:   now,
 		},
 		{
@@ -68,7 +68,7 @@ func TestClient(t *testing.T) {
 			Name:   "test.events.quantity",
 			Value:  0,
 			Sample: 1,
-			Tags:   Tags{{"hello", "world"}},
+			Tags:   Tags{{"hello", "world"}, {"question", "answer"}},
 			Time:   now,
 		},
 		{
@@ -76,7 +76,7 @@ func TestClient(t *testing.T) {
 			Name:   "test.events.seconds",
 			Value:  1,
 			Sample: 1,
-			Tags:   Tags{{"hello", "world"}},
+			Tags:   Tags{{"hello", "world"}, {"question", "answer"}},
 			Time:   now,
 		},
 		{

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -22,6 +22,10 @@ func (t httpTransport) RoundTrip(req *http.Request) (res *http.Response, err err
 	var clock = t.metrics.RTT.Start()
 	var tags stats.Tags
 
+	if t.transport == nil {
+		t.transport = http.DefaultTransport
+	}
+
 	req.Body, tags = t.metrics.ObserveRequest(req)
 	res, err = t.transport.RoundTrip(req)
 	req.Body.Close() // safe guard, the transport should have done it already

--- a/metric.go
+++ b/metric.go
@@ -200,7 +200,7 @@ func (c *clock) StampAt(name string, time time.Time, tags ...Tag) {
 func (c *clock) Stop(tags ...Tag) { c.StopAt(c.now(), tags...) }
 
 func (c *clock) StopAt(time time.Time, tags ...Tag) {
-	c.stamp("stop", time.Sub(c.start).Seconds(), time, tags...)
+	c.stamp("total", time.Sub(c.start).Seconds(), time, tags...)
 }
 
 func (c *clock) stamp(name string, duration float64, time time.Time, tags ...Tag) {


### PR DESCRIPTION
@f2prateek Part two of the memory optimizations, this time in the top level package.

The issue was, in order to maintain the their immutable state and avoid adding internal synchronization to support access from multiple goroutines the metrics were making copies of themselves on the fly to add the extra tags that were passed, but the most common case is to not have extra tags (they're usually set when the metric is created) so these copies were useless.

To optimize for the case where tags are actually passed this PR also adds three memory pools, one for each metric type which caches the copied metrics when the copy is mandatory.

Here are the memory profiles showing the issue:
<img width="1460" alt="screen shot 2016-08-27 at 12 08 37 am" src="https://cloud.githubusercontent.com/assets/865510/18025837/84ab9a24-6bea-11e6-9faa-a900bd5ed37f.png">
![screen shot 2016-08-26 at 7 06 19 pm](https://cloud.githubusercontent.com/assets/865510/18025813/fad0dd82-6be9-11e6-9dbd-9316242aa0bf.png)
Here are the memory profiles after the changes:
<img width="1242" alt="screen shot 2016-08-26 at 11 54 43 pm" src="https://cloud.githubusercontent.com/assets/865510/18025814/fd009444-6be9-11e6-859c-cce07d8bbe6b.png">
<img width="1131" alt="screen shot 2016-08-26 at 11 55 21 pm" src="https://cloud.githubusercontent.com/assets/865510/18025816/08536240-6bea-11e6-8bf5-f5a406b78f92.png">

We can also see that the memory usage on the benchmark has gone from 20K to 5.5K objects and from 1.8MB to 650KB, huge improvements again!
