### PR TITLE
simplify go metrics

### DIFF
--- a/procstats/go_test.go
+++ b/procstats/go_test.go
@@ -43,7 +43,7 @@ func TestGoMetricsMock(t *testing.T) {
 	gostats.gc.NumGC = 1
 	gostats.gc.Pause = []time.Duration{time.Microsecond}
 	gostats.gc.PauseEnd = []time.Time{now.Add(-time.Second)}
-	gostats.updateMemStats(time.Now(), time.Microsecond, time.Microsecond)
+	gostats.updateMemStats(time.Now())
 
 	if len(backend.Events) == 0 {
 		t.Error("no events were generated while collecting memory stats")

--- a/procstats/proc_darwin.go
+++ b/procstats/proc_darwin.go
@@ -1,6 +1,7 @@
 package procstats
 
 func collectProcMetrics(pid int) (m proc, err error) {
+	getclktck()
 	// TODO
 	return
 }


### PR DESCRIPTION
@f2prateek 

Bunch of optimizations again, get rid of useless metrics that were causing huge numbers of memory allocations.

Basically the issue was in the Collects metric was setting tags dynamically which means the tags will be copied into a new slice.

I also got rid of the stats for memory allocation breakdown per memory bucket... the profiling tools are powerful enough that we don't need these data and they're generating huuuuuuge amount of metrics.

Let me know if you'd like to see anything changed.
