### PR TITLE
optional connection tags

### DIFF
--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -21,7 +21,8 @@ func TestConn(t *testing.T) {
 	})
 	defer client.Close()
 
-	conn := NewConn(&testConn{}, client)
+	c := &testConn{}
+	conn := NewConn(c, client, NewConnTags(c, TagAll)...)
 	conn.Write([]byte("Hello World!"))
 	conn.Read(make([]byte, 10))
 	conn.Read(make([]byte, 10))
@@ -119,7 +120,8 @@ func TestConnError(t *testing.T) {
 	})
 	defer client.Close()
 
-	conn := NewConn(&testConn{err: testError}, client)
+	c := &testConn{err: testError}
+	conn := NewConn(c, client, NewConnTags(c, TagAll)...)
 	conn.SetDeadline(now)
 	conn.SetReadDeadline(now)
 	conn.SetWriteDeadline(now)


### PR DESCRIPTION
@segmentio/infra 
@f2prateek 

Datadog reached out to us saying we were creating too many custom metrics, this change intends to give the ability to control what tags will be set on the low-level connection metrics so we can remove local_port and remote_port.

Please take a look and let me know if something should be changed.