### PR TITLE
add dogstatsd utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 
 # Emacs
 *~
+
+# Commands
+/dogstatsd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+COPY . /go/src/github.com/segmentio/stats
+
+ENV CGO_ENABLED=0
+RUN apk add --no-cache git && \
+    cd /go/src/github.com/segmentio/stats && \
+    go build -v -o /dogstatsd ./cmd/dogstatsd && \
+    apk del git && \
+    rm -rf /go/*
+
+ENTRYPOINT ["/dogstatsd"]

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+
+	"github.com/segmentio/stats/datadog"
+)
+
+func main() {
+	var bind string
+
+	flag.StringVar(&bind, "bind", ":8125", "The network address to listen on for incoming UDP datagrams")
+	flag.Parse()
+	log.Printf("listening for incoming UDP datagram on %s", bind)
+
+	datadog.ListenAndServe(bind, datadog.HandlerFunc(func(metric datadog.Metric, from net.Addr) {
+		log.Print(metric)
+	}))
+}

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -1,6 +1,10 @@
 package datadog
 
-import "github.com/segmentio/stats"
+import (
+	"testing"
+
+	"github.com/segmentio/stats"
+)
 
 var testMetrics = []struct {
 	s string
@@ -115,4 +119,14 @@ var testMetrics = []struct {
 			Tags:  []stats.Tag{{"country", "china"}},
 		},
 	},
+}
+
+func TestMetricString(t *testing.T) {
+	for _, test := range testMetrics {
+		t.Run(test.s, func(t *testing.T) {
+			if s := test.m.String(); s != test.s {
+				t.Error(s)
+			}
+		})
+	}
 }


### PR DESCRIPTION
@calvinfo 
@yields 
@f2prateek 

Adds the cmd/dogstatsd utility, it's a small server that listens for dogstatsd datagrams on a UDP address and outputs them to stdout. Should be really useful for debugging.

It also comes with a docker image to easily run it anywhere => https://hub.docker.com/r/segment/dogstatsd/tags/