### PR TITLE
fix counter bug

### DIFF
--- a/datadog/client.go
+++ b/datadog/client.go
@@ -205,7 +205,7 @@ func metrics(state []stats.Metric, counters map[string]counter, now time.Time) [
 			}
 
 			counters[m.Key] = counter{
-				value:   value,
+				value:   m.Value,
 				modTime: now,
 			}
 

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -45,6 +45,11 @@ func TestServer(t *testing.T) {
 	ma.Incr()
 	ma.Incr()
 
+	// Test that the counter properly computes the delta between flushes of the
+	// client.
+	time.Sleep(10 * time.Millisecond)
+	ma.Incr()
+
 	mb := stats.MakeGauge(engine, "B")
 	mb.Set(1)
 	mb.Set(2)
@@ -57,7 +62,7 @@ func TestServer(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadUint32(&a); n != 2 { // two increments (+1, +1)
+	if n := atomic.LoadUint32(&a); n != 3 { // two increments (+1, +1, +1)
 		t.Error("datadog.test.A: bad count:", n)
 	}
 


### PR DESCRIPTION
@tysonmote 
@dominicbarnes 
@calvinfo 

Indeed there was something wrong with the implementation, basically the datadog client is computing the delta between two flushes that it makes but instead of remembering the last value of the counter it was keeping the delta, which means values in the next flush would be meaningless.

I added a test that verified the behavior, it was missed before because the tests only verified that the values were right within a single flush.