### PR TITLE
adjust the socket buffer size on the datadog UDP socket

### DIFF
--- a/datadog/client.go
+++ b/datadog/client.go
@@ -4,8 +4,10 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/segmentio/stats"
@@ -102,24 +104,61 @@ func (c *Client) close() {
 	<-c.join
 }
 
+func socket(address string, sizehint int) (conn net.Conn, bufsize int, err error) {
+	var f *os.File
+
+	if conn, err = net.Dial("udp", address); err != nil {
+		return
+	}
+
+	if f, err = conn.(*net.UDPConn).File(); err != nil {
+		conn.Close()
+		return
+	}
+	defer f.Close()
+	fd := int(f.Fd())
+
+	if bufsize, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF); err != nil {
+		conn.Close()
+		return
+	}
+
+	for sizehint > bufsize && sizehint > 0 {
+		if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, sizehint); err == nil {
+			bufsize = sizehint
+			break
+		}
+		sizehint /= 2
+	}
+
+	// Creating the file put the socket in blocking mode, reverting.
+	syscall.SetNonblock(fd, true)
+	return
+}
+
 func run(c ClientConfig, tick *time.Ticker, done <-chan struct{}, join chan<- struct{}, timeout time.Duration) {
+	var bufferSize int
+
 	defer close(join)
 	defer tick.Stop()
 
-	if c.Output == nil {
+	for c.Output == nil {
 		var err error
-		if c.Output, err = net.Dial("udp", c.Address); err != nil {
+		if c.Output, bufferSize, err = socket(c.Address, c.BufferSize); err != nil {
 			log.Printf("stats/datadog: %s", err)
-			return
+			select {
+			case <-time.After(1 * time.Second):
+			case <-done:
+				return
+			}
 		}
 	}
-
 	defer c.Output.Close()
 
 	var version uint64                      // last version seen by the client
 	var counters = make(map[string]counter) // cache of previous counter values
 	var b1 = make([]byte, 0, 1024)
-	var b2 = make([]byte, 0, c.BufferSize)
+	var b2 = make([]byte, 0, bufferSize)
 
 	// On each tick, fetch the state of the engine and write the metrics that
 	// have changed since the last loop iteration.


### PR DESCRIPTION
I noticed an issue on OSX (but it probably was happening on Linux as well) where the stats package would log an error saying the messages were too big.

It turns out the kernel discards UDP datagrams that are bigger than the kernel buffer for the socket, so this PR tries its best to allocate the largest kernel buffer for the socket and use that value as a limit when buffering dogstatsd metrics.