### PR TITLE
set default buckets for histograms

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -72,7 +72,7 @@ func (eng *Engine) Register(handler Handler) {
 }
 
 // HistogramBuckets returns a map of metric names to buckets used to distribute
-// hitogram values.
+// histogram values.
 //
 // The buckets are of list of upper limits used to group the observed values.
 func (eng *Engine) HistogramBuckets() map[string][]float64 {

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -13,6 +13,47 @@ import (
 	"github.com/segmentio/stats"
 )
 
+func init() {
+	stats.DefaultEngine.SetHistogramBucket("http.message.header.size",
+		5,
+		10,
+		20,
+		40,
+		80,
+		math.Inf(+1),
+	)
+
+	stats.DefaultEngine.SetHistogramBucket("http.message.header.bytes",
+		1e2, // 100 B
+		1e3, // 1 KB
+		1e4, // 10 KB
+		1e5, // 100 KB
+		1e6, // 1 MB
+		math.Inf(+1),
+	)
+
+	stats.DefaultEngine.SetHistogramBucket("http.message.body.bytes",
+		1e2, // 100 B
+		1e3, // 1 KB
+		1e4, // 10 KB
+		1e5, // 100 KB
+		1e6, // 1 MB
+		1e7, // 10 MB
+		1e8, // 100 MB
+		1e9, // 1 GB
+		math.Inf(+1),
+	)
+
+	stats.DefaultEngine.SetHistogramBucket("http.rtt.seconds",
+		1e-3, // 1ms
+		1e-2, // 10ms
+		1e-1, // 100ms
+		1,    // 1s
+		10,   // 10s
+		math.Inf(+1),
+	)
+}
+
 type nullBody struct{}
 
 func (n *nullBody) Close() error { return nil }

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	stats.DefaultEngine.SetHistogramBucket("http.message.header.size",
+	stats.DefaultEngine.SetHistogramBuckets("http.message.header.size",
 		5,
 		10,
 		20,
@@ -23,7 +23,7 @@ func init() {
 		math.Inf(+1),
 	)
 
-	stats.DefaultEngine.SetHistogramBucket("http.message.header.bytes",
+	stats.DefaultEngine.SetHistogramBuckets("http.message.header.bytes",
 		1e2, // 100 B
 		1e3, // 1 KB
 		1e4, // 10 KB
@@ -32,7 +32,7 @@ func init() {
 		math.Inf(+1),
 	)
 
-	stats.DefaultEngine.SetHistogramBucket("http.message.body.bytes",
+	stats.DefaultEngine.SetHistogramBuckets("http.message.body.bytes",
 		1e2, // 100 B
 		1e3, // 1 KB
 		1e4, // 10 KB
@@ -44,7 +44,7 @@ func init() {
 		math.Inf(+1),
 	)
 
-	stats.DefaultEngine.SetHistogramBucket("http.rtt.seconds",
+	stats.DefaultEngine.SetHistogramBuckets("http.rtt.seconds",
 		1e-3, // 1ms
 		1e-2, // 10ms
 		1e-1, // 100ms

--- a/metric.go
+++ b/metric.go
@@ -57,6 +57,10 @@ type Metric struct {
 
 	// Time is unused for now, reserved for future extensions.
 	Time time.Time
+
+	// For histograms, this field provides the buckets used to distribute the
+	// observed values.
+	Buckets []float64
 }
 
 // metricPool is used as an internal store to cache metric objects.

--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	stats.DefaultEngine.SetHistogramBucket("conn.read.bytes",
+	stats.DefaultEngine.SetHistogramBuckets("conn.read.bytes",
 		1e2, // 100 B
 		1e3, // 1 KB
 		1e4, // 10 KB
@@ -20,7 +20,7 @@ func init() {
 		math.Inf(+1),
 	)
 
-	stats.DefaultEngine.SetHistogramBucket("conn.write.bytes",
+	stats.DefaultEngine.SetHistogramBuckets("conn.write.bytes",
 		1e2, // 100 B
 		1e3, // 1 KB
 		1e4, // 10 KB

--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -2,6 +2,7 @@ package netstats
 
 import (
 	"io"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -9,6 +10,24 @@ import (
 	"github.com/segmentio/netx"
 	"github.com/segmentio/stats"
 )
+
+func init() {
+	stats.DefaultEngine.SetHistogramBucket("conn.read.bytes",
+		1e2, // 100 B
+		1e3, // 1 KB
+		1e4, // 10 KB
+		1e5, // 100 KB
+		math.Inf(+1),
+	)
+
+	stats.DefaultEngine.SetHistogramBucket("conn.write.bytes",
+		1e2, // 100 B
+		1e3, // 1 KB
+		1e4, // 10 KB
+		1e5, // 100 KB
+		math.Inf(+1),
+	)
+}
 
 // NewConn returns a net.Conn object that wraps c and produces metrics on the
 // default engine.

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -11,13 +11,13 @@ import (
 
 func init() {
 	stats.DefaultEngine.SetHistogramBucket("go.memstats.gc_pause.seconds",
-		1e-6,  // 1us
-		10e-5, // 10us
-		10e-4, // 100us
-		10e-3, // 1ms
-		10e-2, // 10ms
-		10e-1, // 100ms
-		1,     // 1s
+		1e-6, // 1us
+		1e-5, // 10us
+		1e-4, // 100us
+		1e-3, // 1ms
+		1e-2, // 10ms
+		1e-1, // 100ms
+		1,    // 1s
 		math.Inf(+1),
 	)
 }

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -1,12 +1,26 @@
 package procstats
 
 import (
+	"math"
 	"runtime"
 	"runtime/debug"
 	"time"
 
 	"github.com/segmentio/stats"
 )
+
+func init() {
+	stats.DefaultEngine.SetHistogramBucket("go.memstats.gc_pause.seconds",
+		1e-6,  // 1us
+		10e-5, // 10us
+		10e-4, // 100us
+		10e-3, // 1ms
+		10e-2, // 10ms
+		10e-1, // 100ms
+		1,     // 1s
+		math.Inf(+1),
+	)
+}
 
 // GoMetrics is a metric collector that reports metrics from the Go runtime.
 type GoMetrics struct {

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	stats.DefaultEngine.SetHistogramBucket("go.memstats.gc_pause.seconds",
+	stats.DefaultEngine.SetHistogramBuckets("go.memstats.gc_pause.seconds",
 		1e-6, // 1us
 		1e-5, // 10us
 		1e-4, // 100us

--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -18,16 +18,9 @@ import (
 //
 // Typically, a program creates one Handler, registers it to the stats package,
 // and adds it to the muxer used by the application under the /metrics path.
+//
+// The handle ignores histograms that have no buckets set.
 type Handler struct {
-	// A map of metric name to histograms buckets used by the handler to record
-	// observed values.
-	//
-	// The buckets are of list of upper limits used to group the observed
-	// values.
-	//
-	// If a bucket is missing for a metric name the observed value is ignored.
-	HistogramBuckets map[string][]float64
-
 	// MetricTimeout defines how long the handler exposes metrics that aren't
 	// receiving updates.
 	//
@@ -56,7 +49,7 @@ func (h *Handler) HandleMetric(m *stats.Metric) {
 		value:  m.Value,
 		time:   mtime,
 		labels: cache.labels,
-	}, h.HistogramBuckets[m.Name])
+	}, m.Buckets)
 
 	cache.labels = cache.labels[:0]
 	handleMetricPool.Put(cache)

--- a/prometheus/handler_test.go
+++ b/prometheus/handler_test.go
@@ -54,21 +54,20 @@ func TestAcceptEncoding(t *testing.T) {
 func TestServeHTTP(t *testing.T) {
 	now := time.Date(2017, 6, 4, 22, 12, 0, 0, time.UTC)
 
-	handler := &Handler{
-		HistogramBuckets: map[string][]float64{"C": {0.25, 0.5, 0.75, 1.0}},
-	}
+	handler := &Handler{}
+	buckets := []float64{0.25, 0.5, 0.75, 1.0}
 
 	input := []stats.Metric{
 		{Type: stats.CounterType, Name: "A", Value: 1, Time: now},
 		{Type: stats.CounterType, Name: "A", Value: 2, Time: now},
-		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now},
+		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now, Buckets: buckets},
 		{Type: stats.GaugeType, Name: "B", Value: 1, Time: now, Tags: []stats.Tag{{"a", "1"}, {"b", "2"}}},
 		{Type: stats.CounterType, Name: "A", Value: 4, Time: now, Tags: []stats.Tag{{"id", "123"}}},
 		{Type: stats.GaugeType, Name: "B", Value: 42, Time: now, Tags: []stats.Tag{{"a", "1"}}},
-		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now},
+		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now, Buckets: buckets},
 		{Type: stats.GaugeType, Name: "B", Value: 21, Time: now, Tags: []stats.Tag{{"b", "2"}, {"a", "1"}}},
-		{Type: stats.HistogramType, Name: "C", Value: 0.5, Time: now},
-		{Type: stats.HistogramType, Name: "C", Value: 10, Time: now},
+		{Type: stats.HistogramType, Name: "C", Value: 0.5, Time: now, Buckets: buckets},
+		{Type: stats.HistogramType, Name: "C", Value: 10, Time: now, Buckets: buckets},
 	}
 
 	for i := range input {
@@ -117,17 +116,17 @@ func BenchmarkHandleMetric(b *testing.B) {
 	now := time.Now()
 	tags := []stats.Tag{{"a", "1"}, {"b", "2"}}
 
+	buckets := []float64{0.25, 0.5, 0.75, 1.0}
 	metrics := []stats.Metric{
 		{Type: stats.CounterType, Name: "A", Value: 1, Time: now, Tags: tags},
 		{Type: stats.GaugeType, Name: "B", Value: 1, Time: now, Tags: tags},
-		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now, Tags: tags},
+		{Type: stats.HistogramType, Name: "C", Value: 0.1, Time: now, Tags: tags, Buckets: buckets},
 	}
 
 	for _, metric := range metrics {
 		b.Run(metric.Type.String(), func(b *testing.B) {
-			handler := &Handler{
-				HistogramBuckets: map[string][]float64{"C": {0.25, 0.5, 0.75, 1.0}},
-			}
+			handler := &Handler{}
+
 			for i := 0; i != b.N; i++ {
 				handler.HandleMetric(&metric)
 			}


### PR DESCRIPTION
This PR adds default buckets for the histograms generated by the stats sub-packages. The intent is to have things work out of the box with prometheus.

Please take a look and let me know if anything should be changed.