### PR TITLE
fix missing scope on prometheus histograms

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -310,6 +310,7 @@ func (state *metricState) collect(metrics []metric, entry *metricEntry) []metric
 			cumulativeCount += bucket.count
 			metrics = append(metrics, metric{
 				mtype:  entry.mtype,
+				scope:  entry.scope,
 				name:   entry.bucket,
 				help:   entry.help,
 				value:  float64(cumulativeCount),
@@ -320,6 +321,7 @@ func (state *metricState) collect(metrics []metric, entry *metricEntry) []metric
 		metrics = append(metrics,
 			metric{
 				mtype:  entry.mtype,
+				scope:  entry.scope,
 				name:   entry.sum,
 				help:   entry.help,
 				value:  state.sum,
@@ -328,6 +330,7 @@ func (state *metricState) collect(metrics []metric, entry *metricEntry) []metric
 			},
 			metric{
 				mtype:  entry.mtype,
+				scope:  entry.scope,
 				name:   entry.count,
 				help:   entry.help,
 				value:  float64(state.count),

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestMetricStore(t *testing.T) {
 	input := []metric{
-		{mtype: counter, name: "A", value: 1},
-		{mtype: counter, name: "A", value: 2},
-		{mtype: histogram, name: "C", value: 0.1},
-		{mtype: gauge, name: "B", value: 1, labels: labels{{"a", "1"}, {"b", "2"}}},
-		{mtype: counter, name: "A", value: 4, labels: labels{{"id", "123"}}},
-		{mtype: gauge, name: "B", value: 42, labels: labels{{"a", "1"}}},
-		{mtype: histogram, name: "C", value: 0.1},
-		{mtype: gauge, name: "B", value: 21, labels: labels{{"a", "1"}, {"b", "2"}}},
-		{mtype: histogram, name: "C", value: 0.5},
-		{mtype: histogram, name: "C", value: 10},
+		{mtype: counter, scope: "test", name: "A", value: 1},
+		{mtype: counter, scope: "test", name: "A", value: 2},
+		{mtype: histogram, scope: "test", name: "C", value: 0.1},
+		{mtype: gauge, scope: "test", name: "B", value: 1, labels: labels{{"a", "1"}, {"b", "2"}}},
+		{mtype: counter, scope: "test", name: "A", value: 4, labels: labels{{"id", "123"}}},
+		{mtype: gauge, scope: "test", name: "B", value: 42, labels: labels{{"a", "1"}}},
+		{mtype: histogram, scope: "test", name: "C", value: 0.1},
+		{mtype: gauge, scope: "test", name: "B", value: 21, labels: labels{{"a", "1"}, {"b", "2"}}},
+		{mtype: histogram, scope: "test", name: "C", value: 0.5},
+		{mtype: histogram, scope: "test", name: "C", value: 10},
 	}
 
 	store := metricStore{}
@@ -32,16 +32,16 @@ func TestMetricStore(t *testing.T) {
 	sort.Sort(byNameAndLabels(metrics))
 
 	expects := []metric{
-		{mtype: counter, name: "A", value: 3, labels: labels{}},
-		{mtype: counter, name: "A", value: 4, labels: labels{{"id", "123"}}},
-		{mtype: gauge, name: "B", value: 42, labels: labels{{"a", "1"}}},
-		{mtype: gauge, name: "B", value: 21, labels: labels{{"a", "1"}, {"b", "2"}}},
-		{mtype: histogram, name: "C_bucket", value: 2, labels: labels{{"le", "0.25"}}},
-		{mtype: histogram, name: "C_bucket", value: 3, labels: labels{{"le", "0.5"}}},
-		{mtype: histogram, name: "C_bucket", value: 3, labels: labels{{"le", "0.75"}}},
-		{mtype: histogram, name: "C_bucket", value: 3, labels: labels{{"le", "1"}}},
-		{mtype: histogram, name: "C_count", value: 4, labels: labels{}},
-		{mtype: histogram, name: "C_sum", value: 10.7, labels: labels{}},
+		{mtype: counter, scope: "test", name: "A", value: 3, labels: labels{}},
+		{mtype: counter, scope: "test", name: "A", value: 4, labels: labels{{"id", "123"}}},
+		{mtype: gauge, scope: "test", name: "B", value: 42, labels: labels{{"a", "1"}}},
+		{mtype: gauge, scope: "test", name: "B", value: 21, labels: labels{{"a", "1"}, {"b", "2"}}},
+		{mtype: histogram, scope: "test", name: "C_bucket", value: 2, labels: labels{{"le", "0.25"}}},
+		{mtype: histogram, scope: "test", name: "C_bucket", value: 3, labels: labels{{"le", "0.5"}}},
+		{mtype: histogram, scope: "test", name: "C_bucket", value: 3, labels: labels{{"le", "0.75"}}},
+		{mtype: histogram, scope: "test", name: "C_bucket", value: 3, labels: labels{{"le", "1"}}},
+		{mtype: histogram, scope: "test", name: "C_count", value: 4, labels: labels{}},
+		{mtype: histogram, scope: "test", name: "C_sum", value: 10.7, labels: labels{}},
 	}
 
 	if !reflect.DeepEqual(metrics, expects) {


### PR DESCRIPTION
I noticed an issue where the metric namespaces were not set on prometheus histograms. This PR fixes it.