### PR TITLE
allow use of unsorted labels

### DIFF
--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -49,10 +49,9 @@ type Handler struct {
 	// sorting step by setting this flag to true.
 	//
 	// Note that in the context of the stats package tags are usually always
-	// presented in the same order since the APIs receive a slice of stats.Tag
-	// which preserves the order in which they're passed. Unless the program is
-	// dynamically gneerating the slice of tags it's very likely that it will be
-	// able to take advantage of skipping the sorting step.
+	// presented in the same order since the APIs receive a slice of stats.Tag.
+	// Unless the program is dynamically gneerating the slice of tags it's very
+	// likely that it will be able to take advantage of skipping the sort.
 	//
 	// By default this flag is set to false to ensure correctness in every case.
 	UseUnsortedLabels bool


### PR DESCRIPTION
We noticed performance issues on one of our applications due to the fact that the metric labels need to always be used in a consistent order, one way to achieve it is sorting them, another is to rely on the fact that the tags are always presented in the same order.

The intent of this pull request is to offer the program the option to skip the sorting step if it can guarantee that it won't generate metrics with reordered tags.