### PR TITLE
use atomic operations instead of mutexes in Counter and Gauge

### DIFF
--- a/atomic.go
+++ b/atomic.go
@@ -1,0 +1,41 @@
+package stats
+
+import (
+	"math"
+	"sync/atomic"
+	"unsafe"
+)
+
+type f64 uint64
+
+func (a *f64) ptr() *uint64 {
+	return (*uint64)(unsafe.Pointer(a))
+}
+
+func (a *f64) float() float64 {
+	return math.Float64frombits(atomic.LoadUint64(a.ptr()))
+}
+
+func (a *f64) add(f float64) float64 {
+	for {
+		p := a.ptr()
+		v := atomic.LoadUint64(p)
+		x := math.Float64frombits(v) + f
+
+		if atomic.CompareAndSwapUint64(p, v, math.Float64bits(x)) {
+			return x
+		}
+	}
+}
+
+func (a *f64) set(f float64) (value float64, delta float64) {
+	for {
+		p := a.ptr()
+		v := atomic.LoadUint64(p)
+		x := math.Float64frombits(v)
+
+		if atomic.CompareAndSwapUint64(p, v, math.Float64bits(f)) {
+			return f, f - x
+		}
+	}
+}

--- a/counter.go
+++ b/counter.go
@@ -62,9 +62,9 @@ func (c *Counter) Add(value float64) {
 // This method is useful for reporting values of counters that aren't managed
 // by the application itself, like CPU ticks for example.
 func (c *Counter) Set(value float64) {
-	_, value = c.value.set(value)
-	if value < 0 {
-		value = -value
+	_, delta := c.value.set(value)
+	if delta >= 0 {
+		value = delta
 	}
 	c.eng.Add(c.name, value, c.tags...)
 }

--- a/gauge.go
+++ b/gauge.go
@@ -1,11 +1,8 @@
 package stats
 
-import "sync"
-
 // A Gauge represent a metric that reports a single value.
 type Gauge struct {
-	mutex sync.Mutex
-	value float64 // current value of the gauge
+	value f64     // current value of the gauge
 	eng   *Engine // the engine to produce metrics on
 	name  string  // the name of the gauge
 	tags  []Tag   // the tags set on the gauge
@@ -27,7 +24,7 @@ func (g *Gauge) Tags() []Tag {
 
 // Value returns the current value of the gauge.
 func (g *Gauge) Value() float64 {
-	return g.value
+	return g.value.float()
 }
 
 // WithTags returns a copy of the gauge, potentially setting tags on the returned
@@ -54,16 +51,12 @@ func (g *Gauge) Decr() {
 
 // Add adds a value to the gauge.
 func (g *Gauge) Add(value float64) {
-	g.mutex.Lock()
-	g.value += value
-	g.eng.Set(g.name, g.value, g.tags...)
-	g.mutex.Unlock()
+	value = g.value.add(value)
+	g.eng.Set(g.name, value, g.tags...)
 }
 
 // Set sets the gauge to value.
 func (g *Gauge) Set(value float64) {
-	g.mutex.Lock()
-	g.value = value
+	value, _ = g.value.set(value)
 	g.eng.Set(g.name, value, g.tags...)
-	g.mutex.Unlock()
 }


### PR DESCRIPTION
This is the first of a couple of PRs I'm going to submit to attempt to make metric collection a bit faster.
While profiling production software I noticed that metric collection was taking an important part of the time spent, there were a couple of short wins like getting rid of some unused metrics or increasing the datadog client buffer size but now I'm down to having to optimize the code itself.

This PR changes the implementation of Counter and Gauge to use atomic operations instead of mutexes, which trims ~15% of time spent in the Counter and Gauge methods.
On top of being a quicker operation to execute this is also the kind of change which usually helps programs achieve higher throughput as there's no contention point anymore where goroutines may be paused.

Here are numbers from the benchmarks:
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkCounter/Incr-4     64.4          54.8          -14.91%
BenchmarkCounter/Add-4      61.7          52.1          -15.56%
BenchmarkCounter/Set-4      59.3          52.7          -11.13%
BenchmarkGauge/Incr-4       64.7          55.0          -14.99%
BenchmarkGauge/Decr-4       62.3          55.2          -11.40%
BenchmarkGauge/Add-4        63.1          53.2          -15.69%
BenchmarkGauge/Set-4        62.8          52.5          -16.40%
```

Please take a look and let me know if you have any concerns.