### PR TITLE
optinally allow http path tags in datadog client

### DIFF
--- a/datadog/append.go
+++ b/datadog/append.go
@@ -33,18 +33,9 @@ func appendMetric(b []byte, m Metric) []byte {
 
 func appendTags(b []byte, tags []stats.Tag) []byte {
 	for i, t := range tags {
-		if t.Name == "http_req_path" {
-			// Datadog has complained numerous times that the request paths
-			// generate too many custom metrics on their side, for now we'll
-			// simply strip it out until we can come up with a better strategy
-			// for handling those.
-			continue
-		}
-
 		if i != 0 {
 			b = append(b, ',')
 		}
-
 		b = append(b, t.Name...)
 		b = append(b, ':')
 		b = append(b, t.Value...)


### PR DESCRIPTION
Historically we disabled the `http_req_path` tag that the httpstats package sets on metrics because there were cases where we had paths that embedded user IDs with a cardinality higher than what datadog can handle.

However there are cases where we have more control over what the HTTP requests path looks like, which means we could leverage the tag in those cases.

This PR makes it possible to lift the restriction on the `http_req_path`.