### PR TITLE
Add RPC stats.

### DIFF
--- a/rpcstats/invoker.go
+++ b/rpcstats/invoker.go
@@ -1,0 +1,61 @@
+package rpcstats
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/segmentio/rpc"
+	"github.com/segmentio/stats"
+)
+
+type invoker struct {
+	invoker rpc.Invoker
+	eng     *stats.Engine
+}
+
+// NewInvoker wraps a RPC invoker to produce metrics for every RPC call.
+func NewInvoker(i rpc.Invoker) rpc.Invoker {
+	return NewInvokerWith(stats.DefaultEngine, i)
+}
+
+// NewInvoker wraps a RPC invoker to produce metrics on eng for every RPC call.
+func NewInvokerWith(eng *stats.Engine, i rpc.Invoker) rpc.Invoker {
+	return &invoker{
+		invoker: i,
+		eng:     eng,
+	}
+}
+
+func (i *invoker) Invoke(ctx context.Context, req rpc.Request) (res interface{}, err error) {
+	parts := strings.SplitN(req.Method, ".", 2)
+	resource := parts[0]
+	function := strings.Join(parts[1:], ".")
+
+	var tags []stats.Tag
+	tags = append(tags, stats.Tag{"method", req.Method})
+	tags = append(tags, stats.Tag{"resource", resource})
+	tags = append(tags, stats.Tag{"function", function})
+
+	start := time.Now()
+
+	defer func() {
+		end := time.Now()
+
+		if r := recover(); r != nil {
+			tags = append(tags, stats.Tag{"result", "panic"})
+			// We want to capture stats, but still propagate errors upstream.
+			defer panic(r)
+		} else if err != nil {
+			tags = append(tags, stats.Tag{"result", "error"})
+		} else {
+			tags = append(tags, stats.Tag{"result", "success"})
+		}
+
+		i.eng.Incr("jsonrpc.call", tags...)
+		i.eng.Observe("jsonrpc.duration", end.Sub(start), tags...)
+	}()
+
+	res, err = i.invoker.Invoke(ctx, req)
+	return
+}

--- a/rpcstats/invoker_test.go
+++ b/rpcstats/invoker_test.go
@@ -1,0 +1,122 @@
+package rpcstats
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/segmentio/rpc"
+	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
+	"github.com/stretchr/testify/assert"
+)
+
+type math struct{}
+
+func (m math) Add(ctx context.Context, nums []int) (sum int, err error) {
+	for _, n := range nums {
+		sum += n
+	}
+	return
+}
+
+func (m math) Error(ctx context.Context, nums []int) (sum int, err error) {
+	return 0, errors.New("test")
+}
+
+func (m math) Panic(ctx context.Context, nums []int) (sum int, err error) {
+	panic("test")
+}
+
+func setup(t *testing.T) (*statstest.Handler, *rpc.Client, func()) {
+	h := &statstest.Handler{}
+	e := stats.NewEngine("", h)
+
+	srv := rpc.NewServer()
+	srv.Register("Math", NewInvokerWith(e, rpc.NewService(math{})))
+
+	server := httptest.NewServer(srv)
+	client := rpc.NewClient(rpc.ClientConfig{
+		UserAgent: "math-client",
+		URL:       server.URL + "/rpc",
+	})
+
+	return h, client, func() {
+		server.Close()
+	}
+}
+
+func TestInvokerNormal(t *testing.T) {
+	h, client, done := setup(t)
+	defer done()
+
+	var res int
+	err := client.Call(context.Background(), "Math.Add", []int{2, 2}, &res)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, res)
+
+	assert.Equal(t, 2, len(h.Measures()))
+
+	for _, m := range h.Measures() {
+		if !strings.Contains(m.Name, "jsonrpc") {
+			t.Errorf("expected metric %q to contain \"jsonrpc\" but did not", m.Name)
+		}
+
+		assert.Equal(t, []stats.Tag{
+			{"function", "Add"},
+			{"method", "Math.Add"},
+			{"resource", "Math"},
+			{"result", "success"},
+		}, m.Tags)
+	}
+}
+
+func TestInvokerError(t *testing.T) {
+	h, client, done := setup(t)
+	defer done()
+
+	var res int
+	err := client.Call(context.Background(), "Math.Error", []int{2, 2}, &res)
+	assert.Error(t, err)
+
+	assert.Equal(t, 2, len(h.Measures()))
+
+	for _, m := range h.Measures() {
+		if !strings.Contains(m.Name, "jsonrpc") {
+			t.Errorf("expected metric %q to contain \"jsonrpc\" but did not", m.Name)
+		}
+
+		assert.Equal(t, []stats.Tag{
+			{"function", "Error"},
+			{"method", "Math.Error"},
+			{"resource", "Math"},
+			{"result", "error"},
+		}, m.Tags)
+	}
+}
+
+func TestInvokerPanic(t *testing.T) {
+	h, client, done := setup(t)
+	defer done()
+
+	var res int
+	err := client.Call(context.Background(), "Math.Panic", []int{2, 2}, &res)
+	assert.Error(t, err)
+
+	assert.Equal(t, 2, len(h.Measures()))
+
+	for _, m := range h.Measures() {
+		if !strings.Contains(m.Name, "jsonrpc") {
+			t.Errorf("expected metric %q to contain \"jsonrpc\" but did not", m.Name)
+		}
+
+		assert.Equal(t, []stats.Tag{
+			{"function", "Panic"},
+			{"method", "Math.Panic"},
+			{"resource", "Math"},
+			{"result", "panic"},
+		}, m.Tags)
+	}
+}

--- a/statstest/handler.go
+++ b/statstest/handler.go
@@ -1,0 +1,31 @@
+package statstest
+
+import (
+	"sync"
+	"time"
+
+	"github.com/segmentio/stats"
+)
+
+var _ stats.Handler = (*Handler)(nil)
+
+type Handler struct {
+	sync.Mutex
+	measures []stats.Measure
+}
+
+func (h *Handler) HandleMeasures(time time.Time, measures ...stats.Measure) {
+	h.Lock()
+	for _, m := range measures {
+		h.measures = append(h.measures, m.Clone())
+	}
+	h.Unlock()
+}
+
+func (h *Handler) Measures() []stats.Measure {
+	h.Lock()
+	m := make([]stats.Measure, len(h.measures))
+	copy(m, h.measures)
+	h.Unlock()
+	return m
+}


### PR DESCRIPTION
This adds an RPC invoker implementation that records RPC stats.

It records 2 stats:

1. Counter for `jsonrpc.call`.
2. Histogram for `jsonrpc.duration`.

Each of these contains the following tags:
1. `method` - the RPC method.
2. `resource` - the resource if the method is of the form
"resource.function".
3. `function` - the function if the method is of the form
"resource.function".
4.  `result` - either "error", "success", "panic".