### PR TITLE
Add statstest package.

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/segmentio/stats/datadog"
 	"github.com/segmentio/stats/influxdb"
 	"github.com/segmentio/stats/prometheus"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestEngine(t *testing.T) {
@@ -65,7 +66,7 @@ func TestEngine(t *testing.T) {
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
 			t.Parallel()
-			h := &testHandler{}
+			h := &statstest.Handler{}
 			testFunc(t, stats.NewEngine("test", h, stats.Tag{"service", "test-service"}))
 		})
 	}
@@ -110,7 +111,7 @@ func testEngineFlush(t *testing.T, eng *stats.Engine) {
 	eng.Flush()
 	eng.Flush()
 
-	h := eng.Handler.(*testHandler)
+	h := eng.Handler.(*statstest.Handler)
 
 	if n := h.FlushCalls(); n != 3 {
 		t.Error("bad number of flush calls:", n)
@@ -258,7 +259,7 @@ func testEngineReportSlice(t *testing.T, eng *stats.Engine) {
 }
 
 func checkMeasuresEqual(t *testing.T, eng *stats.Engine, expected ...stats.Measure) {
-	found := eng.Handler.(*testHandler).Measures()
+	found := eng.Handler.(*statstest.Handler).Measures()
 	if !reflect.DeepEqual(found, expected) {
 		t.Error("bad measures:")
 		t.Logf("expected: %#v", expected)

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,43 +1,12 @@
 package stats_test
 
 import (
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
-
-type testHandler struct {
-	mutex    sync.Mutex
-	measures []stats.Measure
-	flush    int32
-}
-
-func (h *testHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
-	h.mutex.Lock()
-	for _, m := range measures {
-		h.measures = append(h.measures, m.Clone())
-	}
-	h.mutex.Unlock()
-}
-
-func (h *testHandler) Measures() []stats.Measure {
-	h.mutex.Lock()
-	measures := make([]stats.Measure, len(h.measures))
-	copy(measures, h.measures)
-	h.mutex.Unlock()
-	return measures
-}
-
-func (h *testHandler) Flush() {
-	atomic.AddInt32(&h.flush, 1)
-}
-
-func (h *testHandler) FlushCalls() int {
-	return int(atomic.LoadInt32(&h.flush))
-}
 
 func TestMultiHandler(t *testing.T) {
 	t.Run("calling HandleMeasures on a multi-handler dispatches to each handler", func(t *testing.T) {
@@ -53,8 +22,8 @@ func TestMultiHandler(t *testing.T) {
 	})
 
 	t.Run("calling Flush on a multi-handler flushes each handler", func(t *testing.T) {
-		h1 := &testHandler{}
-		h2 := &testHandler{}
+		h1 := &statstest.Handler{}
+		h2 := &statstest.Handler{}
 
 		m := stats.MultiHandler(h1, h2)
 		flush(m)

--- a/httpstats/handler_test.go
+++ b/httpstats/handler_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestHandler(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	server := httptest.NewServer(NewHandlerWith(e, http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -53,7 +54,7 @@ func TestHandler(t *testing.T) {
 }
 
 func TestHandlerHijack(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	server := httptest.NewServer(NewHandlerWith(e, http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/httpstats/metrics_test.go
+++ b/httpstats/metrics_test.go
@@ -6,34 +6,10 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
-	"github.com/segmentio/stats"
 	"github.com/segmentio/stats/iostats"
 )
-
-type measureHandler struct {
-	sync.Mutex
-	measures []stats.Measure
-}
-
-func (h *measureHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
-	h.Lock()
-	for _, m := range measures {
-		h.measures = append(h.measures, m.Clone())
-	}
-	h.Unlock()
-}
-
-func (h *measureHandler) Measures() []stats.Measure {
-	h.Lock()
-	m := make([]stats.Measure, len(h.measures))
-	copy(m, h.measures)
-	h.Unlock()
-	return m
-}
 
 func TestResponseStatusBucket(t *testing.T) {
 	tests := []struct {

--- a/httpstats/transport_test.go
+++ b/httpstats/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestTransport(t *testing.T) {
@@ -29,7 +30,7 @@ func TestTransport(t *testing.T) {
 				newRequest("POST", "/", strings.NewReader("Hi")),
 			} {
 				t.Run("", func(t *testing.T) {
-					h := &measureHandler{}
+					h := &statstest.Handler{}
 					e := stats.NewEngine("", h)
 
 					server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -53,11 +54,11 @@ func TestTransport(t *testing.T) {
 					ioutil.ReadAll(res.Body)
 					res.Body.Close()
 
-					if len(h.measures) == 0 {
+					if len(h.Measures()) == 0 {
 						t.Error("no measures reported by http handler")
 					}
 
-					for _, m := range h.measures {
+					for _, m := range h.Measures() {
 						for _, tag := range m.Tags {
 							if tag.Name == "bucket" {
 								switch tag.Value {
@@ -75,7 +76,7 @@ func TestTransport(t *testing.T) {
 }
 
 func TestTransportError(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -10,17 +10,8 @@ import (
 	"time"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
-
-type measureHandler struct {
-	measures []stats.Measure
-}
-
-func (h *measureHandler) HandleMeasures(t time.Time, ms ...stats.Measure) {
-	for _, m := range ms {
-		h.measures = append(h.measures, m.Clone())
-	}
-}
 
 func TestBaseConn(t *testing.T) {
 	c1 := &testConn{}
@@ -32,7 +23,7 @@ func TestBaseConn(t *testing.T) {
 }
 
 func TestConn(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
 	c := &testConn{}
@@ -75,15 +66,15 @@ func TestConn(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expected, h.measures) {
+	if !reflect.DeepEqual(expected, h.Measures()) {
 		t.Error("bad measures:")
 		t.Logf("expected: %v", expected)
-		t.Logf("found:    %v", h.measures)
+		t.Logf("found:    %v", h.Measures())
 	}
 }
 
 func TestConnError(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
 	now := time.Now()
@@ -173,10 +164,10 @@ func TestConnError(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expected, h.measures) {
+	if !reflect.DeepEqual(expected, h.Measures()) {
 		t.Error("bad measures:")
 		t.Logf("expected: %v", expected)
-		t.Logf("found:    %v", h.measures)
+		t.Logf("found:    %v", h.Measures())
 	}
 }
 

--- a/netstats/listener_test.go
+++ b/netstats/listener_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestListener(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
 	lstn := NewListenerWith(e, testLstn{})
@@ -36,15 +37,15 @@ func TestListener(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expected, h.measures) {
+	if !reflect.DeepEqual(expected, h.Measures()) {
 		t.Error("bad measures:")
 		t.Logf("expected: %v", expected)
-		t.Logf("found:    %v", h.measures)
+		t.Logf("found:    %v", h.Measures())
 	}
 }
 
 func TestListenerError(t *testing.T) {
-	h := &measureHandler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
 	lstn := NewListenerWith(e, testLstn{err: errTest})
@@ -65,10 +66,10 @@ func TestListenerError(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expected, h.measures) {
+	if !reflect.DeepEqual(expected, h.Measures()) {
 		t.Error("bad measures:")
 		t.Logf("expected: %v", expected)
-		t.Logf("found:    %v", h.measures)
+		t.Logf("found:    %v", h.Measures())
 	}
 }
 

--- a/procstats/collector_test.go
+++ b/procstats/collector_test.go
@@ -5,20 +5,11 @@ import (
 	"time"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
-type handler struct {
-	measures []stats.Measure
-}
-
-func (h *handler) HandleMeasures(time time.Time, measures ...stats.Measure) {
-	for _, m := range measures {
-		h.measures = append(h.measures, m.Clone())
-	}
-}
-
 func TestCollector(t *testing.T) {
-	h := &handler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	c := StartCollectorWith(Config{
@@ -32,11 +23,11 @@ func TestCollector(t *testing.T) {
 	time.Sleep(time.Millisecond)
 	c.Close()
 
-	if len(h.measures) == 0 {
+	if len(h.Measures()) == 0 {
 		t.Error("no measures were reported by the stats collector")
 	}
 
-	for _, m := range h.measures {
+	for _, m := range h.Measures() {
 		t.Log(m)
 	}
 }

--- a/procstats/go_test.go
+++ b/procstats/go_test.go
@@ -7,20 +7,21 @@ import (
 	"time"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestGoMetrics(t *testing.T) {
-	h := &handler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	gostats := NewGoMetricsWith(e)
 	gostats.Collect()
 
-	if len(h.measures) == 0 {
+	if len(h.Measures()) == 0 {
 		t.Error("no measures were reported by the stats collector")
 	}
 
-	for _, m := range h.measures {
+	for _, m := range h.Measures() {
 		t.Log(m)
 	}
 }

--- a/procstats/proc_test.go
+++ b/procstats/proc_test.go
@@ -5,20 +5,21 @@ import (
 	"testing"
 
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestProcMetrics(t *testing.T) {
-	h := &handler{}
+	h := &statstest.Handler{}
 	e := stats.NewEngine("", h)
 
 	proc := NewProcMetricsWith(e, os.Getpid())
 	proc.Collect()
 
-	if len(h.measures) == 0 {
+	if len(h.Measures()) == 0 {
 		t.Error("no measures were reported by the stats collector")
 	}
 
-	for _, m := range h.measures {
+	for _, m := range h.Measures() {
 		t.Log(m)
 	}
 }

--- a/redisstats/handler_test.go
+++ b/redisstats/handler_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/segmentio/redis-go"
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestHandler(t *testing.T) {
-	m := &testMeasureHandler{}
-	e := stats.NewEngine("", m)
+	statsHandler := &statstest.Handler{}
+	e := stats.NewEngine("", statsHandler)
 
 	h := NewHandlerWith(e, &testRedisHandler{})
 
@@ -28,7 +29,7 @@ func TestHandler(t *testing.T) {
 	h.ServeRedis(&testResponseWriter{err: errors.New("fail")},
 		redis.NewRequest("127.0.0.1:6379", "SET", redis.List("foo", "bar")))
 
-	measures := m.Measures()
+	measures := statsHandler.Measures()
 	if len(measures) == 0 {
 		t.Error("no measures were produced")
 	}

--- a/redisstats/metrics_test.go
+++ b/redisstats/metrics_test.go
@@ -2,36 +2,12 @@ package redisstats
 
 import (
 	"reflect"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/segmentio/stats"
 )
 
-type testMeasureHandler struct {
-	sync.Mutex
-	measures []stats.Measure
-}
-
-func (h *testMeasureHandler) Measures() []stats.Measure {
-	h.Lock()
-	c := make([]stats.Measure, len(h.measures))
-	copy(c, h.measures)
-	h.Unlock()
-	return c
-}
-
-func (h *testMeasureHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
-	h.Lock()
-	for _, m := range measures {
-		h.measures = append(h.measures, m.Clone())
-	}
-	h.Unlock()
-}
-
 func validateMeasure(t *testing.T, found stats.Measure, expect stats.Measure) {
 	if !reflect.DeepEqual(found, expect) {
 	}
-
 }

--- a/redisstats/transport_test.go
+++ b/redisstats/transport_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/segmentio/objconv/resp"
 	"github.com/segmentio/redis-go"
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/statstest"
 )
 
 func TestTransport(t *testing.T) {
-	m := &testMeasureHandler{}
-	e := stats.NewEngine("", m)
+	h := &statstest.Handler{}
+	e := stats.NewEngine("", h)
 
 	client := redis.Client{
 		Addr:      "127.0.0.1",
@@ -45,7 +46,7 @@ func TestTransport(t *testing.T) {
 	readErrorClient.Do(redis.NewRequest("9.9.9.9:6379", "GET", redis.List("foo")))
 	writeErrorClient.Do(redis.NewRequest("9.9.9.9:6379", "SET", redis.List("foo", "bar")))
 
-	measures := m.Measures()
+	measures := h.Measures()
 	if len(measures) == 0 {
 		t.Error("no measures were produced")
 	}

--- a/statstest/handler.go
+++ b/statstest/handler.go
@@ -1,0 +1,45 @@
+package statstest
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/segmentio/stats"
+)
+
+var _ stats.Handler = (*Handler)(nil)
+var _ stats.Flusher = (*Handler)(nil)
+
+// Handler is a stats handler that can record measures for inspection.
+type Handler struct {
+	sync.Mutex
+	measures []stats.Measure
+	flush    int32
+}
+
+func (h *Handler) HandleMeasures(time time.Time, measures ...stats.Measure) {
+	h.Lock()
+	for _, m := range measures {
+		h.measures = append(h.measures, m.Clone())
+	}
+	h.Unlock()
+}
+
+// Measures returns a copy of the handled measures.
+func (h *Handler) Measures() []stats.Measure {
+	h.Lock()
+	m := make([]stats.Measure, len(h.measures))
+	copy(m, h.measures)
+	h.Unlock()
+	return m
+}
+
+func (h *Handler) Flush() {
+	atomic.AddInt32(&h.flush, 1)
+}
+
+// FlushCalls returns the number of times `Flush` has been invoked.
+func (h *Handler) FlushCalls() int {
+	return int(atomic.LoadInt32(&h.flush))
+}


### PR DESCRIPTION
The `statstest` package contains a single `stats.Handler` implementation
that records its measures for inspection. It also implements
`stats.Flusher` so tests can inspect number of times `Flush` was
invoked.

Also removes replaces custom test handlers with the one from the new
`statstest` package.