### PR TITLE
fix metric buffering

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -20,7 +20,7 @@ type Buffer struct {
 	// Note that if the buffer size is small, the program may generate metrics
 	// that don't fit into the configured buffer size. In that case the buffer
 	// will still pass the serialized byte slice to its Serializer to leave the
-	// decision of
+	// decision of accepting or rejecting the metrics.
 	BufferSize int
 
 	// The Serializer used to write the measures.

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -2,6 +2,9 @@ package datadog
 
 import (
 	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +30,40 @@ func TestClient(t *testing.T) {
 
 	if err := client.Close(); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestClientWriteLargeMetrics(t *testing.T) {
+	const data = `main.http.error.count:0|c|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity
+main.http.message.count:1|c|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,operation:read,type:request
+main.http.message.header.size:2|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,operation:read,type:request
+main.http.message.header.bytes:240|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,operation:read,type:request
+main.http.message.body.bytes:0|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,operation:read,type:request
+main.http.message.count:1|c|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,http_res_content_charset:,http_res_content_endoing:,http_res_content_type:application/json,http_res_protocol:HTTP/1.1,http_res_server:,http_res_transfer_encoding:identity,http_res_upgrade:,http_status:200,http_status_bucket:2xx,operation:write,type:response
+main.http.message.header.size:1|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,http_res_content_charset:,http_res_content_endoing:,http_res_content_type:application/json,http_res_protocol:HTTP/1.1,http_res_server:,http_res_transfer_encoding:identity,http_res_upgrade:,http_status:200,http_status_bucket:2xx,operation:write,type:response
+main.http.message.header.bytes:70|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,http_res_content_charset:,http_res_content_endoing:,http_res_content_type:application/json,http_res_protocol:HTTP/1.1,http_res_server:,http_res_transfer_encoding:identity,http_res_upgrade:,http_status:200,http_status_bucket:2xx,operation:write,type:response
+main.http.message.body.bytes:839|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,http_res_content_charset:,http_res_content_endoing:,http_res_content_type:application/json,http_res_protocol:HTTP/1.1,http_res_server:,http_res_transfer_encoding:identity,http_res_upgrade:,http_status:200,http_status_bucket:2xx,operation:write,type:response
+main.http.rtt.seconds:0.001215296|h|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity,http_res_content_charset:,http_res_content_endoing:,http_res_content_type:application/json,http_res_protocol:HTTP/1.1,http_res_server:,http_res_transfer_encoding:identity,http_res_upgrade:,http_status:200,http_status_bucket:2xx,operation:write,type:response
+`
+
+	count := int32(0)
+	expect := int32(strings.Count(data, "\n"))
+
+	addr, closer := startTestServer(t, HandlerFunc(func(m Metric, _ net.Addr) {
+		atomic.AddInt32(&count, 1)
+	}))
+	defer closer.Close()
+
+	client := NewClient(addr)
+
+	if _, err := client.Write([]byte(data)); err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if n := atomic.LoadInt32(&count); n != expect {
+		t.Error("bad metric count:", n)
 	}
 }
 


### PR DESCRIPTION
Prateek reported a bug on v4, I tracked it down to an issue when a single serialized measure ends up being larger than the client buffer size.

This PR addresses the issue by making the following changes:
- don't try to aggregate metrics into the client buffer if their serialized data is already larger than the client buffer size
- modify the datadog client to split byte buffers on `\n` characters if the byte slice being written is larger than its known socket buffer size