### PR TITLE
Grafana

### DIFF
--- a/grafana/annotations.go
+++ b/grafana/annotations.go
@@ -10,7 +10,7 @@ import (
 // AnnotationsHandler is the handler for the /annotations endpoint in the
 // simple-json-datasource API.
 type AnnotationsHandler interface {
-	ServeAnnotations(ctx context.Context)
+	ServeAnnotations(ctx context.Context) error
 }
 
 // NewAnnotationsHandler returns a new http.Handler which delegates /annotations API calls

--- a/grafana/annotations.go
+++ b/grafana/annotations.go
@@ -3,6 +3,8 @@ package grafana
 import (
 	"context"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/segmentio/objconv"
 )
@@ -10,19 +12,135 @@ import (
 // AnnotationsHandler is the handler for the /annotations endpoint in the
 // simple-json-datasource API.
 type AnnotationsHandler interface {
-	ServeAnnotations(ctx context.Context) error
+	// ServeAnnotations
+	ServeAnnotations(ctx context.Context, res AnnotationsResponse, req *AnnotationsRequest) error
+}
+
+// AnnotationsHandlerFunc makes it possible to use regular function types as annotations
+// handlers.
+type AnnotationsHandlerFunc func(context.Context, AnnotationsResponse, *AnnotationsRequest) error
+
+// ServeAnnotations calls f, satisfies the AnnotationsHandler interface.
+func (f AnnotationsHandlerFunc) ServeAnnotations(ctx context.Context, res AnnotationsResponse, req *AnnotationsRequest) error {
+	return f(ctx, res, req)
+}
+
+// AnnotationsResponse is an interface used to an annotations request.
+type AnnotationsResponse interface {
+	// WriteAnnotation writes an annotation to the response. The method may be
+	// called multiple times.
+	WriteAnnotation(Annotation)
+}
+
+// AnnotationsRequest represents a request received on the /annotations
+// endpoint.
+//
+// Note: It's not really clear if this request is intended to add a new
+// annotation into the data source, neither how the name and datasource fields
+// are supposed to be used. It seems to work to treat it as a read-only request
+// for annotations on the given time range and query.
+type AnnotationsRequest struct {
+	From       time.Time
+	To         time.Time
+	Name       string
+	Datasource string
+	IconColor  string
+	Query      string
+	Enable     bool
+}
+
+// Annotation represents a single Grafana annotation.
+type Annotation struct {
+	Time     time.Time
+	Title    string
+	Text     string
+	Enabled  bool
+	ShowLine bool
+	Tags     []string
 }
 
 // NewAnnotationsHandler returns a new http.Handler which delegates /annotations API calls
 // to the given annotations handler.
 func NewAnnotationsHandler(handler AnnotationsHandler) http.Handler {
-	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+	return handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
+		req := annotationsRequest{}
+		res := annotationsResponse{enc: enc}
 
-		return
+		if err := dec.Decode(&req); err != nil {
+			return err
+		}
+
+		res.name = req.Annotation.Name
+		res.datasource = req.Annotation.Datasource
+
+		if err := handler.ServeAnnotations(ctx, &res, &AnnotationsRequest{
+			From:       req.Range.From,
+			To:         req.Range.To,
+			Name:       req.Annotation.Name,
+			Datasource: req.Annotation.Datasource,
+			IconColor:  req.Annotation.IconColor,
+			Query:      req.Annotation.Query,
+			Enable:     req.Annotation.Enable,
+		}); err != nil {
+			return err
+		}
+
+		return enc.Close()
 	})
 }
 
 // HandleAnnotations installs a handler on /annotations.
 func HandleAnnotations(mux *http.ServeMux, handler AnnotationsHandler) {
 	mux.Handle("/annotations", NewAnnotationsHandler(handler))
+}
+
+type annotationsRequest struct {
+	Range struct {
+		From time.Time `json:"from"`
+		To   time.Time `json:"to"`
+	} `json:"range"`
+
+	Annotation struct {
+		Name       string `json:"name"`
+		Datasource string `json:"datasource"`
+		IconColor  string `json:"iconColor"`
+		Query      string `json:"query"`
+		Enable     bool   `json:"enable"`
+	} `json:"annotation"`
+}
+
+type annotationsResponse struct {
+	enc        *objconv.StreamEncoder
+	name       string
+	datasource string
+}
+
+func (res *annotationsResponse) WriteAnnotation(a Annotation) {
+	res.enc.Encode(annotationInfo{
+		Annotation: annotation{
+			Name:       res.name,
+			Datasource: res.datasource,
+			Enabled:    a.Enabled,
+			ShowLine:   a.ShowLine,
+		},
+		Time:  timestamp(a.Time),
+		Title: a.Title,
+		Text:  a.Text,
+		Tags:  strings.Join(a.Tags, ", "),
+	})
+}
+
+type annotationInfo struct {
+	Annotation annotation `json:"annotation"`
+	Time       int64      `json:"time"`
+	Title      string     `json:"title"`
+	Text       string     `json:"text,omitempty"`
+	Tags       string     `json:"tags,omitempty"`
+}
+
+type annotation struct {
+	Name       string `json:"name"`
+	Datasource string `json:"datasource"`
+	Enabled    bool   `json:"enabled"`
+	ShowLine   bool   `json:"showLine"`
 }

--- a/grafana/annotations.go
+++ b/grafana/annotations.go
@@ -1,0 +1,28 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/segmentio/objconv"
+)
+
+// AnnotationsHandler is the handler for the /annotations endpoint in the
+// simple-json-datasource API.
+type AnnotationsHandler interface {
+	ServeAnnotations(ctx context.Context)
+}
+
+// NewAnnotationsHandler returns a new http.Handler which delegates /annotations API calls
+// to the given annotations handler.
+func NewAnnotationsHandler(handler AnnotationsHandler) http.Handler {
+	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+
+		return
+	})
+}
+
+// HandleAnnotations installs a handler on /annotations.
+func HandleAnnotations(mux *http.ServeMux, handler AnnotationsHandler) {
+	mux.Handle("/annotations", NewAnnotationsHandler(handler))
+}

--- a/grafana/annotations_test.go
+++ b/grafana/annotations_test.go
@@ -1,0 +1,104 @@
+package grafana
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAnnotationsHandler(t *testing.T) {
+	t0 := time.Date(2017, 8, 16, 12, 34, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Minute)
+
+	ar := annotationsRequest{}
+	ar.Range.From = t0
+	ar.Range.To = t1
+	ar.Annotation.Name = "name"
+	ar.Annotation.Datasource = "test"
+	ar.Annotation.IconColor = "rgba(255, 96, 96, 1)"
+	ar.Annotation.Query = "events"
+	ar.Annotation.Enable = true
+
+	b, _ := json.Marshal(ar)
+
+	client := http.Client{}
+	server := httptest.NewServer(NewAnnotationsHandler(
+		AnnotationsHandlerFunc(func(ctx context.Context, res AnnotationsResponse, req *AnnotationsRequest) error {
+			if !req.From.Equal(ar.Range.From) {
+				t.Error("bad 'from' time:", req.From, ar.Range.From)
+			}
+
+			if !req.To.Equal(ar.Range.To) {
+				t.Error("bad 'to' time:", req.To, ar.Range.To)
+			}
+
+			if req.Name != ar.Annotation.Name {
+				t.Error("bad name:", req.Name, "!=", ar.Annotation.Name)
+			}
+
+			if req.Datasource != ar.Annotation.Datasource {
+				t.Error("bad datasource:", req.Datasource, "!=", ar.Annotation.Datasource)
+			}
+
+			if req.IconColor != ar.Annotation.IconColor {
+				t.Error("bad icon color:", req.IconColor, "!=", ar.Annotation.IconColor)
+			}
+
+			if req.Query != ar.Annotation.Query {
+				t.Error("bad query:", req.Query, "!=", ar.Annotation.Query)
+			}
+
+			if req.Enable != ar.Annotation.Enable {
+				t.Error("not enabled:", req.Enable, "!=", ar.Annotation.Enable)
+			}
+
+			res.WriteAnnotation(Annotation{
+				Time:     t0,
+				Title:    "yay!",
+				Text:     "we did it!",
+				Enabled:  true,
+				ShowLine: true,
+				Tags:     []string{"A", "B", "C"},
+			})
+
+			return nil
+		}),
+	))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/annotations?pretty", bytes.NewReader(b))
+
+	r, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+
+	found, _ := ioutil.ReadAll(r.Body)
+	expect := annotationsResult
+
+	if s := string(found); s != expect {
+		t.Error(s)
+		t.Log(expect)
+	}
+}
+
+const annotationsResult = `[
+  {
+    "annotation": {
+      "name": "name",
+      "datasource": "test",
+      "enabled": true,
+      "showLine": true
+    },
+    "time": 1502886840000,
+    "title": "yay!",
+    "text": "we did it!",
+    "tags": "A, B, C"
+  }
+]`

--- a/grafana/handler.go
+++ b/grafana/handler.go
@@ -1,0 +1,72 @@
+package grafana
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/segmentio/objconv"
+	"github.com/segmentio/objconv/json"
+)
+
+// Handler is an interface that must be implemented by types that intend to act
+// as a grafana data source using the simple-json-datasource plugin.
+//
+// See https://github.com/grafana/simple-json-datasource for more details about
+// the implementation.
+type Handler interface {
+	AnnotationsHandler
+	QueryHandler
+	SearchHandler
+}
+
+// NewHandler returns a new http.Handler that implements the
+// simple-json-datasource API.
+func NewHandler(handler Handler) http.Handler {
+	mux := http.NewServeMux()
+	Handle(mux, handler)
+	return mux
+}
+
+// Handle installs a handler implementing the simple-json-datasource API on mux.
+//
+// The function adds three routes to mux, for /annotations, /query, and /search.
+func Handle(mux *http.ServeMux, handler Handler) {
+	HandleAnnotations(mux, handler)
+	HandleQuery(mux, handler)
+	HandleSearch(mux, handler)
+
+	// Registering a global handler is a common thing that applications do, to
+	// avoid overriding one that may already exist we first check that none were
+	// previously registered.
+	if _, pattern := mux.Handler(&http.Request{
+		URL: &url.URL{Path: "/"},
+	}); len(pattern) == 0 {
+		mux.Handle("/", handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
+			return nil
+		}))
+	}
+}
+
+func handlerFunc(f func(context.Context, *objconv.StreamEncoder, *objconv.Decoder) error) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		h := res.Header()
+		h.Set("Access-Control-Allow-Headers", "Accept, Content-Type")
+		h.Set("Access-Control-Allow-Methods", "POST")
+		h.Set("Access-Control-Allow-Origin", "*")
+		h.Set("Content-Type", "application/json; charset=utf-8")
+		h.Set("Server", "stats/grafana (simple-json-datasource)")
+
+		err := f(
+			req.Context(),
+			json.NewStreamEncoder(res),
+			json.NewDecoder(req.Body),
+		)
+
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			log.Printf("grafana: %s %s: %s", req.Method, req.URL.Path, err)
+		}
+	})
+}

--- a/grafana/handler.go
+++ b/grafana/handler.go
@@ -76,7 +76,13 @@ func handlerFunc(f func(context.Context, *objconv.StreamEncoder, *objconv.Decode
 		)
 
 		// TODO: support different error types to return different error codes?
-		if err != nil {
+		switch err {
+		case nil:
+		case context.Canceled:
+			res.WriteHeader(http.StatusInternalServerError)
+		case context.DeadlineExceeded:
+			res.WriteHeader(http.StatusGatewayTimeout)
+		default:
 			res.WriteHeader(http.StatusInternalServerError)
 			log.Printf("grafana: %s %s: %s", req.Method, req.URL.Path, err)
 		}

--- a/grafana/handler.go
+++ b/grafana/handler.go
@@ -44,20 +44,15 @@ func Handle(mux *http.ServeMux, handler Handler) {
 	if _, pattern := mux.Handler(&http.Request{
 		URL: &url.URL{Path: "/"},
 	}); len(pattern) == 0 {
-		mux.Handle("/", handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
-			return nil
-		}))
+		mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+			setResponseHeaders(res)
+		})
 	}
 }
 
 func handlerFunc(f func(context.Context, *objconv.StreamEncoder, *objconv.Decoder) error) http.Handler {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		h := res.Header()
-		h.Set("Access-Control-Allow-Headers", "Accept, Content-Type")
-		h.Set("Access-Control-Allow-Methods", "POST")
-		h.Set("Access-Control-Allow-Origin", "*")
-		h.Set("Content-Type", "application/json; charset=utf-8")
-		h.Set("Server", "stats/grafana (simple-json-datasource)")
+		setResponseHeaders(res)
 
 		switch req.Method {
 		case http.MethodPost:
@@ -100,4 +95,13 @@ func newEncoder(res http.ResponseWriter, req *http.Request) *objconv.StreamEncod
 
 func newDecoder(r io.Reader) *objconv.Decoder {
 	return json.NewDecoder(r)
+}
+
+func setResponseHeaders(res http.ResponseWriter) {
+	h := res.Header()
+	h.Set("Access-Control-Allow-Headers", "Accept, Content-Type")
+	h.Set("Access-Control-Allow-Methods", "POST")
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Content-Type", "application/json; charset=utf-8")
+	h.Set("Server", "stats/grafana (simple-json-datasource)")
 }

--- a/grafana/query.go
+++ b/grafana/query.go
@@ -2,7 +2,9 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/segmentio/objconv"
 )
@@ -10,19 +12,234 @@ import (
 // QueryHandler is the handler for the /query endpoint in the
 // simple-json-datasource API.
 type QueryHandler interface {
-	ServeQuery(ctx context.Context)
+	ServeQuery(ctx context.Context, res QueryResponse, req *QueryRequest) error
 }
+
+// QueryHandlerFunc makes it possible to use regular function types as query
+// handlers.
+type QueryHandlerFunc func(context.Context, QueryResponse, *QueryRequest) error
+
+// ServeQuery calls f, satisfies the QueryHandler interface.
+func (f QueryHandlerFunc) ServeQuery(ctx context.Context, res QueryResponse, req *QueryRequest) error {
+	return f(ctx, res, req)
+}
+
+// QueryResponse is an interface used to write the response to a query request.
+type QueryResponse interface {
+	// Timeserie returns a TimeserieWriter which can be used to output the
+	// datapoint in response to a timeserie request.
+	Timeserie(target string) TimeserieWriter
+
+	// Table returns a TableWriter which can be used to output the rows in
+	// response to a table request.
+	Table(columns ...Column) TableWriter
+}
+
+// QueryRequest represents
+type QueryRequest struct {
+	From          time.Time
+	To            time.Time
+	Interval      time.Duration
+	Targets       []Target
+	MaxDataPoints int
+}
+
+// Target is a data structure representing the target of a query.
+type Target struct {
+	Name  string     `json:"target"`
+	RefID string     `json:"refId"`
+	Type  TargetType `json:"type"`
+}
+
+// TargetType is an enumeration of the various target types supported by
+// Grafana.
+type TargetType string
+
+const (
+	Timeserie TargetType = "timeserie"
+	Table     TargetType = "table"
+)
+
+// TimeserieWriter is a
+type TimeserieWriter interface {
+	WriteDatapoint(value float64, time time.Time)
+}
+
+type TableWriter interface {
+	WriteRow(values ...interface{})
+}
+
+// Column is a data structure representing a table column.
+type Column struct {
+	Text string     `json:"text"`
+	Type ColumnType `json:"type"`
+}
+
+// Col constructs a new Column value from a text and column type.
+func Col(text string, colType ColumnType) Column {
+	return Column{Text: text, Type: colType}
+}
+
+// ColumnType is an enumeration of the various column types supported by
+// Grafana.
+type ColumnType string
+
+const (
+	String ColumnType = "string"
+	Time   ColumnType = "time"
+	Number ColumnType = "number"
+)
 
 // NewQueryHandler returns a new http.Handler which delegates /query API calls
 // to the given query handler.
 func NewQueryHandler(handler QueryHandler) http.Handler {
-	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+	return handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
+		var req queryRequest
+		var res = queryResponse{enc: enc}
 
-		return
+		if err := dec.Decode(&req); err != nil {
+			return err
+		}
+
+		if err := handler.ServeQuery(ctx, &res, &QueryRequest{
+			From:          req.Range.From,
+			To:            req.Range.To,
+			Interval:      req.Interval,
+			Targets:       req.Targets,
+			MaxDataPoints: req.MaxDataPoints,
+		}); err != nil {
+			return err
+		}
+
+		return res.close()
 	})
 }
 
 // HandleQuery installs a handler on /query.
 func HandleQuery(mux *http.ServeMux, handler QueryHandler) {
 	mux.Handle("/query", NewQueryHandler(handler))
+}
+
+type queryRange struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+type queryRequest struct {
+	Range         queryRange    `json:"range"`
+	Interval      time.Duration `json:"interval"`
+	Targets       []Target      `json:"targets"`
+	MaxDataPoints int           `json:"maxDataPoints"`
+}
+
+type queryResponse struct {
+	enc       *objconv.StreamEncoder
+	timeserie *timeserie
+	table     *table
+}
+
+func (res *queryResponse) Timeserie(target string) TimeserieWriter {
+	res.flush()
+	res.timeserie = &timeserie{
+		Target:     target,
+		Datapoints: make([]datapoint, 0, 100),
+	}
+	return res.timeserie
+}
+
+func (res *queryResponse) Table(columns ...Column) TableWriter {
+	res.flush()
+	res.table = &table{
+		Columns: columns,
+		Rows:    make([]row, 0, 100),
+		Type:    "table",
+	}
+	return res.table
+}
+
+func (res *queryResponse) close() error {
+	res.flush()
+	return res.enc.Close()
+}
+
+func (res *queryResponse) flush() {
+	if res.timeserie != nil {
+		res.enc.Encode(res.timeserie)
+		res.timeserie.closed = true
+		res.timeserie = nil
+	}
+
+	if res.table != nil {
+		res.enc.Encode(res.table)
+		res.table.closed = true
+		res.table = nil
+	}
+}
+
+type datapoint struct {
+	value float64
+	time  int64
+}
+
+func (d datapoint) EncodeValue(e objconv.Encoder) error {
+	i := 0
+	return e.EncodeArray(2, func(e objconv.Encoder) error {
+		switch i++; i {
+		case 1:
+			return e.Encode(d.value)
+		default:
+			return e.Encode(d.time)
+		}
+	})
+}
+
+type timeserie struct {
+	Target     string      `json:"target"`
+	Datapoints []datapoint `json:"datapoints"`
+	closed     bool        `json:"-"`
+}
+
+func (t *timeserie) WriteDatapoint(value float64, time time.Time) {
+	if t.closed {
+		panic("writing to a timeserie after it was already flushed")
+	}
+
+	t.Datapoints = append(t.Datapoints, datapoint{
+		value: value,
+		time:  timestamp(time),
+	})
+}
+
+type row []interface{}
+
+type table struct {
+	Columns []Column `json:"columns"`
+	Rows    []row    `json:"rows"`
+	Type    string   `json:"type"`
+	closed  bool     `json:"-"`
+}
+
+func (t *table) WriteRow(values ...interface{}) {
+	if t.closed {
+		panic("writing to a table after it was already flushed")
+	}
+
+	if len(values) != len(t.Columns) {
+		panic(fmt.Sprintf("row value count doesn't match the number of columns, expected %d values but got %d", len(t.Columns), len(values)))
+	}
+
+	row := make(row, len(values))
+	copy(row, values)
+
+	for i := range row {
+		if t, ok := row[i].(time.Time); ok {
+			row[i] = timestamp(t)
+		}
+	}
+
+	t.Rows = append(t.Rows, row)
+}
+
+func timestamp(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
 }

--- a/grafana/query.go
+++ b/grafana/query.go
@@ -12,6 +12,12 @@ import (
 // QueryHandler is the handler for the /query endpoint in the
 // simple-json-datasource API.
 type QueryHandler interface {
+	// ServeQuery is expected to reply with a list of data points for the given
+	// "target" and time range (or a set of rows for table requests).
+	//
+	// Note: my understanding is that "target" is some kind of identifier that
+	// describes some data set in the source (like a SQL query for example), but
+	// it's treated as an opaque blob of data by Grafana itself.
 	ServeQuery(ctx context.Context, res QueryResponse, req *QueryRequest) error
 }
 
@@ -109,8 +115,8 @@ const (
 // to the given query handler.
 func NewQueryHandler(handler QueryHandler) http.Handler {
 	return handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
-		var req queryRequest
-		var res = queryResponse{enc: enc}
+		req := queryRequest{}
+		res := queryResponse{enc: enc}
 
 		if err := dec.Decode(&req); err != nil {
 			return err

--- a/grafana/query.go
+++ b/grafana/query.go
@@ -217,7 +217,7 @@ func (d datapoint) EncodeValue(e objconv.Encoder) error {
 type timeserie struct {
 	Target     string      `json:"target"`
 	Datapoints []datapoint `json:"datapoints"`
-	closed     bool        `json:"-"`
+	closed     bool
 }
 
 func (t *timeserie) WriteDatapoint(value float64, time time.Time) {
@@ -237,7 +237,7 @@ type table struct {
 	Columns []Column `json:"columns"`
 	Rows    []row    `json:"rows"`
 	Type    string   `json:"type"`
-	closed  bool     `json:"-"`
+	closed  bool
 }
 
 func (t *table) WriteRow(values ...interface{}) {

--- a/grafana/query.go
+++ b/grafana/query.go
@@ -1,0 +1,28 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/segmentio/objconv"
+)
+
+// QueryHandler is the handler for the /query endpoint in the
+// simple-json-datasource API.
+type QueryHandler interface {
+	ServeQuery(ctx context.Context)
+}
+
+// NewQueryHandler returns a new http.Handler which delegates /query API calls
+// to the given query handler.
+func NewQueryHandler(handler QueryHandler) http.Handler {
+	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+
+		return
+	})
+}
+
+// HandleQuery installs a handler on /query.
+func HandleQuery(mux *http.ServeMux, handler QueryHandler) {
+	mux.Handle("/query", NewQueryHandler(handler))
+}

--- a/grafana/query.go
+++ b/grafana/query.go
@@ -24,7 +24,7 @@ func (f QueryHandlerFunc) ServeQuery(ctx context.Context, res QueryResponse, req
 	return f(ctx, res, req)
 }
 
-// QueryResponse is an interface used to write the response to a query request.
+// QueryResponse is an interface used to respond to a search request.
 type QueryResponse interface {
 	// Timeserie returns a TimeserieWriter which can be used to output the
 	// datapoint in response to a timeserie request.
@@ -35,7 +35,7 @@ type QueryResponse interface {
 	Table(columns ...Column) TableWriter
 }
 
-// QueryRequest represents
+// QueryRequest represents a request received on the /query endpoint.
 type QueryRequest struct {
 	From          time.Time
 	To            time.Time
@@ -72,7 +72,9 @@ type TableWriter interface {
 // Column is a data structure representing a table column.
 type Column struct {
 	Text string     `json:"text"`
-	Type ColumnType `json:"type"`
+	Type ColumnType `json:"type,omitempty"`
+	Sort bool       `json:"sort,omitempty"`
+	Desc bool       `json:"desc,omitempty"`
 }
 
 // Col constructs a new Column value from a text and column type.
@@ -80,14 +82,27 @@ func Col(text string, colType ColumnType) Column {
 	return Column{Text: text, Type: colType}
 }
 
+// AscCol constructs a ne Column value from a text a column type, which is
+// configured as a sorted column in ascending order.
+func AscCol(text string, colType ColumnType) Column {
+	return Column{Text: text, Type: colType, Sort: true}
+}
+
+// DescCol constructs a ne Column value from a text a column type, which is
+// configured as a sorted column in descending order.
+func DescCol(text string, colType ColumnType) Column {
+	return Column{Text: text, Type: colType, Sort: true, Desc: true}
+}
+
 // ColumnType is an enumeration of the various column types supported by
 // Grafana.
 type ColumnType string
 
 const (
-	String ColumnType = "string"
-	Time   ColumnType = "time"
-	Number ColumnType = "number"
+	Untyped ColumnType = ""
+	String  ColumnType = "string"
+	Time    ColumnType = "time"
+	Number  ColumnType = "number"
 )
 
 // NewQueryHandler returns a new http.Handler which delegates /query API calls

--- a/grafana/query_test.go
+++ b/grafana/query_test.go
@@ -1,0 +1,156 @@
+package grafana
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/segmentio/objconv/json"
+)
+
+func TestQueryHandler(t *testing.T) {
+	t0 := time.Date(2017, 8, 16, 12, 34, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Minute)
+
+	qr := queryRequest{
+		Range:    queryRange{From: t0, To: t1},
+		Interval: 1 * time.Second,
+		Targets: []Target{
+			{Name: "upper_50", RefID: "A", Type: Timeserie},
+			{Name: "upper_75", RefID: "B", Type: Timeserie},
+			{Name: "entries", RefID: "C", Type: Table},
+		},
+		MaxDataPoints: 150,
+	}
+
+	b, _ := json.Marshal(qr)
+
+	client := http.Client{}
+	server := httptest.NewServer(NewQueryHandler(
+		QueryHandlerFunc(func(ctx context.Context, res QueryResponse, req *QueryRequest) error {
+			if !req.From.Equal(t0) {
+				t.Error("bad 'from' time:", req.From, "!=", t0)
+			}
+
+			if !req.To.Equal(t1) {
+				t.Error("bad 'to' time:", req.To, "!=", t1)
+			}
+
+			if req.Interval != qr.Interval {
+				t.Error("bad interval:", req.Interval, "!=", qr.Interval)
+			}
+
+			if req.MaxDataPoints != qr.MaxDataPoints {
+				t.Error("bad max-data-points:", req.MaxDataPoints, "!=", qr.MaxDataPoints)
+			}
+
+			if !reflect.DeepEqual(req.Targets, qr.Targets) {
+				t.Error("bad targets:")
+				t.Log(req.Targets)
+				t.Log(qr.Targets)
+			}
+
+			for _, target := range req.Targets {
+				switch target.Type {
+				case Timeserie:
+					t := res.Timeserie(target.Name)
+					t.WriteDatapoint(622, t0)
+					t.WriteDatapoint(265, t1)
+
+				case Table:
+					t := res.Table(Col("Time", Time), Col("Country", String), Col("Number", Number))
+					t.WriteRow(t0, "SE", 123)
+					t.WriteRow(t0, "DE", 231)
+					t.WriteRow(t1, "US", 321)
+				}
+			}
+
+			return nil
+		}),
+	))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/query?pretty", bytes.NewReader(b))
+
+	r, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+
+	found, _ := ioutil.ReadAll(r.Body)
+	expect := queryResult
+
+	if s := string(found); s != expect {
+		t.Error(s)
+		t.Log(expect)
+	}
+}
+
+const queryResult = `[
+  {
+    "target": "upper_50",
+    "datapoints": [
+      [
+        622,
+        1502886840000
+      ],
+      [
+        265,
+        1502886900000
+      ]
+    ]
+  },
+  {
+    "target": "upper_75",
+    "datapoints": [
+      [
+        622,
+        1502886840000
+      ],
+      [
+        265,
+        1502886900000
+      ]
+    ]
+  },
+  {
+    "columns": [
+      {
+        "text": "Time",
+        "type": "time"
+      },
+      {
+        "text": "Country",
+        "type": "string"
+      },
+      {
+        "text": "Number",
+        "type": "number"
+      }
+    ],
+    "rows": [
+      [
+        1502886840000,
+        "SE",
+        123
+      ],
+      [
+        1502886840000,
+        "DE",
+        231
+      ],
+      [
+        1502886900000,
+        "US",
+        321
+      ]
+    ],
+    "type": "table"
+  }
+]`

--- a/grafana/search.go
+++ b/grafana/search.go
@@ -10,19 +10,75 @@ import (
 // SearchHandler is the handler for the /search endpoint in the
 // simple-json-datasource API.
 type SearchHandler interface {
-	QuerySearch(ctx context.Context) error
+	ServeSearch(ctx context.Context, res SearchResponse, req *SearchRequest) error
+}
+
+// SearchHandlerFunc makes it possible to use regular function types as search
+// handlers.
+type SearchHandlerFunc func(context.Context, SearchResponse, *SearchRequest) error
+
+// ServeSearch calls f, satisfies the SearchHandler interface.
+func (f SearchHandlerFunc) ServeSearch(ctx context.Context, res SearchResponse, req *SearchRequest) error {
+	return f(ctx, res, req)
+}
+
+// SearchResponse is an interface used to response to a search request.
+type SearchResponse interface {
+	// WriteTarget writes target in the response, the method may be called
+	// multiple times.
+	WriteTarget(target string)
+
+	// WriteTargetValue writes the pair of target and value in the response,
+	// the method may be called multiple times.
+	WriteTargetValue(target string, value interface{})
+}
+
+// SearhRequest represents a request received on the /search endpoint.
+type SearchRequest struct {
+	Target string
 }
 
 // NewSearchHandler returns a new http.Handler which delegates /search API calls
 // to the given search handler.
 func NewSearchHandler(handler SearchHandler) http.Handler {
-	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+	return handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
+		var req searchRequest
+		var res = searchResponse{enc: enc}
 
-		return
+		if err := dec.Decode(&req); err != nil {
+			return err
+		}
+
+		if err := handler.ServeSearch(ctx, &res, &SearchRequest{
+			Target: req.Target,
+		}); err != nil {
+			return err
+		}
+
+		return enc.Close()
 	})
 }
 
 // HandleSearch installs a handler on /search.
 func HandleSearch(mux *http.ServeMux, handler SearchHandler) {
 	mux.Handle("/search", NewSearchHandler(handler))
+}
+
+type searchRequest struct {
+	Target string `json:"target"`
+}
+
+type searchResponse struct {
+	enc *objconv.StreamEncoder
+}
+
+func (res *searchResponse) WriteTarget(target string) {
+	res.enc.Encode(target)
+}
+
+func (res *searchResponse) WriteTargetValue(target string, value interface{}) {
+	res.enc.Encode(struct {
+		Target string      `json:"target"`
+		Value  interface{} `json:"value"`
+	}{target, value})
 }

--- a/grafana/search.go
+++ b/grafana/search.go
@@ -10,7 +10,7 @@ import (
 // SearchHandler is the handler for the /search endpoint in the
 // simple-json-datasource API.
 type SearchHandler interface {
-	QuerySearch(ctx context.Context)
+	QuerySearch(ctx context.Context) error
 }
 
 // NewSearchHandler returns a new http.Handler which delegates /search API calls

--- a/grafana/search.go
+++ b/grafana/search.go
@@ -1,0 +1,28 @@
+package grafana
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/segmentio/objconv"
+)
+
+// SearchHandler is the handler for the /search endpoint in the
+// simple-json-datasource API.
+type SearchHandler interface {
+	QuerySearch(ctx context.Context)
+}
+
+// NewSearchHandler returns a new http.Handler which delegates /search API calls
+// to the given search handler.
+func NewSearchHandler(handler SearchHandler) http.Handler {
+	return handlerFunc(func(ctx context.Context, res *objconv.StreamEncoder, req *objconv.Decoder) (err error) {
+
+		return
+	})
+}
+
+// HandleSearch installs a handler on /search.
+func HandleSearch(mux *http.ServeMux, handler SearchHandler) {
+	mux.Handle("/search", NewSearchHandler(handler))
+}

--- a/grafana/search.go
+++ b/grafana/search.go
@@ -10,6 +10,13 @@ import (
 // SearchHandler is the handler for the /search endpoint in the
 // simple-json-datasource API.
 type SearchHandler interface {
+	// ServeSearch is expected to implement the search functionality of a
+	// Grafana data source.
+	//
+	// Note: It's not really clear how search is implemented, I think the
+	// "target" field in the request is some kind of prefix or keyword to
+	// use to return a list of potential matches that can be used in a /query
+	// request.
 	ServeSearch(ctx context.Context, res SearchResponse, req *SearchRequest) error
 }
 
@@ -22,7 +29,7 @@ func (f SearchHandlerFunc) ServeSearch(ctx context.Context, res SearchResponse, 
 	return f(ctx, res, req)
 }
 
-// SearchResponse is an interface used to response to a search request.
+// SearchResponse is an interface used to respond to a search request.
 type SearchResponse interface {
 	// WriteTarget writes target in the response, the method may be called
 	// multiple times.
@@ -42,8 +49,8 @@ type SearchRequest struct {
 // to the given search handler.
 func NewSearchHandler(handler SearchHandler) http.Handler {
 	return handlerFunc(func(ctx context.Context, enc *objconv.StreamEncoder, dec *objconv.Decoder) error {
-		var req searchRequest
-		var res = searchResponse{enc: enc}
+		req := searchRequest{}
+		res := searchResponse{enc: enc}
 
 		if err := dec.Decode(&req); err != nil {
 			return err

--- a/grafana/search_test.go
+++ b/grafana/search_test.go
@@ -1,0 +1,68 @@
+package grafana
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchHandler(t *testing.T) {
+	sr := searchRequest{
+		Target: "upper_50",
+	}
+
+	b, _ := json.Marshal(sr)
+
+	client := http.Client{}
+	server := httptest.NewServer(NewSearchHandler(
+		SearchHandlerFunc(func(ctx context.Context, res SearchResponse, req *SearchRequest) error {
+			if req.Target != sr.Target {
+				t.Error("bad 'from' time:", req.Target, "!=", sr.Target)
+			}
+
+			res.WriteTarget("upper_25")
+			res.WriteTarget("upper_50")
+			res.WriteTarget("upper_90")
+
+			res.WriteTargetValue("upper_25", 1)
+			res.WriteTargetValue("upper_50", 2)
+
+			return nil
+		}),
+	))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/search?pretty", bytes.NewReader(b))
+
+	r, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+
+	found, _ := ioutil.ReadAll(r.Body)
+	expect := searchResult
+
+	if s := string(found); s != expect {
+		t.Error(s)
+		t.Log(expect)
+	}
+}
+
+const searchResult = `[
+  "upper_25",
+  "upper_50",
+  "upper_90",
+  {
+    "target": "upper_25",
+    "value": 1
+  },
+  {
+    "target": "upper_50",
+    "value": 2
+  }
+]`


### PR DESCRIPTION
This PR adds HTTP handlers that implement the simple-json-datasource API so we can build custom grafana datasources.

The documentation on that grafana-plugin isn't great so I left a couple of notes in the code on things that I may have to revisit at some point, however it worked well when I tested it.

There isn't much to review as this is mostly boilerplate code, I just want to let you guys know that this is now an option we have for building visualizations of custom metric collection systems.

Links:
- https://github.com/grafana/simple-json-datasource
- https://github.com/bergquist/fake-simple-json-datasource
- http://docs.grafana.org/plugins/developing/datasources/