### PR TITLE
add clock

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,53 @@
+package stats
+
+import "time"
+
+// The Clock type can be used to report statistics on durations.
+//
+// Clocks are useful to measure the duration taken by sequential execution steps
+// and therefore aren't safe to be used concurrently by multiple goroutines.
+type Clock struct {
+	name  string
+	first time.Time
+	last  time.Time
+	tags  []Tag
+	eng   *Engine
+}
+
+// Stamp reports the time difference between now and the last time the method
+// was called (or since the clock was created).
+//
+// The metric produced by this method call will have a "stamp" tag set to name.
+func (c *Clock) Stamp(name string) {
+	c.StampAt(name, time.Now())
+}
+
+// StampAt reports the time difference between now and the last time the method
+// was called (or since the clock was created).
+//
+// The metric produced by this method call will have a "stamp" tag set to name.
+func (c *Clock) StampAt(name string, now time.Time) {
+	c.observe(name, now.Sub(c.last))
+	c.last = now
+}
+
+// Stop reports the time difference between now and the time the clock was created at.
+//
+// The metric produced by this method call will have a "stamp" tag set to
+// "total".
+func (c *Clock) Stop() {
+	c.StopAt(time.Now())
+}
+
+// StopAt reports the time difference between now and the time the clock was created at.
+//
+// The metric produced by this method call will have a "stamp" tag set to
+// "total".
+func (c *Clock) StopAt(now time.Time) {
+	c.observe("total", now.Sub(c.first))
+}
+
+func (c *Clock) observe(stamp string, d time.Duration) {
+	tags := append(c.tags, Tag{"stamp", stamp})
+	c.eng.Observe(c.name, d, tags...)
+}

--- a/engine.go
+++ b/engine.go
@@ -94,6 +94,20 @@ func (eng *Engine) Observe(name string, value interface{}, tags ...Tag) {
 	eng.measure(name, value, Histogram, tags...)
 }
 
+// Clock returns a new clock identified by name and tags.
+func (eng *Engine) Clock(name string, tags ...Tag) *Clock {
+	cpy := make([]Tag, len(tags), len(tags)+1) // clock always appends a stamp.
+	copy(cpy, tags)
+	now := time.Now()
+	return &Clock{
+		name:  name,
+		first: now,
+		last:  now,
+		tags:  cpy,
+		eng:   eng,
+	}
+}
+
 func (eng *Engine) measure(name string, value interface{}, ftype FieldType, tags ...Tag) {
 	name, field := splitMeasureField(name)
 	mp := measureArrayPool.Get().(*[1]Measure)


### PR DESCRIPTION
basically copy pasted from v3, i think in v3 `total` stamp would actually just measure from `.last`, which means it's not really "total", so changed it to measure from `.first`.

no timing assertions, but willing to add them if you folks think it's necessary.

the goal is to get this:

```
upload stamp=grayscale (2s)
upload stamp=compress (1s)
upload stamp=total (3s) (uses `.first`)
```

I _think_ v3 used to report this:

```
upload stamp=grayscale (2s)
upload stamp=compress (1s)
upload stamp=total (1s) (uses `.last`)
```