### PR TITLE
more accurate GC pause times

### DIFF
--- a/procstats/go.go
+++ b/procstats/go.go
@@ -186,6 +186,12 @@ func (g *GoMetrics) Collect() {
 
 		for _, pause := range g.gc.Pause[1:] {
 			g.memstats.gcPauseAvg += pause
+			switch {
+			case pause < g.memstats.gcPauseMin:
+				g.memstats.gcPauseMin = pause
+			case pause > g.memstats.gcPauseMax:
+				g.memstats.gcPauseMax = pause
+			}
 		}
 
 		g.memstats.gcPauseAvg /= time.Duration(len(g.gc.Pause))


### PR DESCRIPTION
The current values reported for GC pauses are the sum over the collection period (5s), which gives values that aren't very representative of the actual pause time.

This change changes the way the metric is reported to use three gauges for min/max/avg instead of a histogram of the sums.
