### PR TITLE
fix procstats

### DIFF
--- a/procstats/go.go
+++ b/procstats/go.go
@@ -25,7 +25,7 @@ func init() {
 // GoMetrics is a metric collector that reports metrics from the Go runtime.
 type GoMetrics struct {
 	engine  *stats.Engine
-	version string `tag:"version'`
+	version string `tag:"version"`
 
 	runtime struct {
 		// Runtime info.
@@ -59,25 +59,25 @@ type GoMetrics struct {
 
 		// Low-level fixed-size structure allocator statistics.
 		stack struct {
-			inuse   uint64 `metric:"" type:"gauge"` // bytes used by stack allocator
-			sys     uint64 `metric:"" type:"gauge"`
+			inuse   uint64 `metric:"inuse.bytes" type:"gauge"` // bytes used by stack allocator
+			sys     uint64 `metric:"sys.bytes"   type:"gauge"`
 			memtype string `tag:"type"`
 		}
 
 		mspan struct {
-			inuse   uint64 `metric:"" type:"gauge"` // mspan structures
-			sys     uint64 `metric:"" type:"gauge"`
+			inuse   uint64 `metric:"inuse.bytes" type:"gauge"` // mspan structures
+			sys     uint64 `metric:"sys.bytes"   type:"gauge"`
 			memtype string `tag:"type"`
 		}
 
 		mcache struct {
-			inuse   uint64 `metric:"" type:"gauge"` // mcache structures
-			sys     uint64 `metric:"" type:"gauge"`
+			inuse   uint64 `metric:"inuse.bytes" type:"gauge"` // mcache structures
+			sys     uint64 `metric:"sys.bytes"   type:"gauge"`
 			memtype string `tag:"type"`
 		}
 
 		buckhash struct {
-			sys     uint64 `metric:"" type:"gauge"` // profiling bucket hash table
+			sys     uint64 `metric:"sys.bytes" type:"gauge"` // profiling bucket hash table
 			memtype string `tag:"type"`
 		}
 

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -84,11 +84,11 @@ type procThreads struct {
 	// Context switches
 	switches struct {
 		voluntary struct {
-			count uint64 `metric:"count"" type:"counter"`
+			count uint64 `metric:"count" type:"counter"`
 			typ   string `tag:"type"` // voluntary
 		}
 		involuntary struct {
-			count uint64 `metric:"count"" type:"counter"`
+			count uint64 `metric:"count" type:"counter"`
 			typ   string `tag:"type"` // involuntary
 		}
 	} `metric:"switch"`

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -126,11 +126,10 @@ func NewProcMetricsWith(eng *stats.Engine, pid int) *ProcMetrics {
 
 // Collect satsifies the Collector interface.
 func (p *ProcMetrics) Collect() {
-	now := time.Now()
-	interval := now.Sub(p.lastTime)
-	p.lastTime = now
-
 	if m, err := CollectProcInfo(p.pid); err == nil {
+		now := time.Now()
+		interval := now.Sub(p.lastTime)
+
 		p.cpu.user.time = m.CPU.User - p.last.CPU.User
 		p.cpu.user.percent = 100 * float64(p.cpu.user.time) / float64(interval)
 
@@ -155,6 +154,7 @@ func (p *ProcMetrics) Collect() {
 		p.threads.switches.involuntary.count = m.Threads.InvoluntaryContextSwitches - p.last.Threads.InvoluntaryContextSwitches
 
 		p.last = m
+		p.lastTime = now
 		p.engine.Report(p)
 	}
 }

--- a/procstats/proc_darwin.go
+++ b/procstats/proc_darwin.go
@@ -1,27 +1,122 @@
 package procstats
 
+/*
+#include <mach/mach_init.h>
+#include <mach/mach_host.h>
+#include <mach/mach_port.h>
+#include <mach/mach_traps.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <sys/proc_info.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+// Defined in kern/proc_info.c
+extern int proc_pidinfo(int pid, int flavor, uint64_t arg, user_addr_t buffer, uint32_t buffersize, register_t * retval);
+
+// CGO fails to call a macro that just references a global variable...
+#ifdef mach_task_self
+#undef mach_task_self
+static mach_port_t mach_task_self() { return mach_task_self_; }
+#endif
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
 func collectProcInfo(pid int) (info ProcInfo, err error) {
-	getclktck()
-	// TODO
+	defer func() { err = convertPanicToError(recover()) }()
+
+	if pid != os.Getpid() {
+		panic(errors.New("on darwin systems only metrics of the current process can be collected"))
+	}
+
+	self := C.mach_port_name_t(C.mach_task_self())
+	task := C.mach_port_name_t(0)
+	checkKern(C.task_for_pid(self, C.int(pid), &task))
+
+	rusage := syscall.Rusage{}
+	check(syscall.Getrusage(syscall.RUSAGE_SELF, &rusage))
+
+	nofile := syscall.Rlimit{}
+	check(syscall.Getrlimit(syscall.RLIMIT_NOFILE, &nofile))
+
+	info.CPU.User = time.Duration(rusage.Utime.Nano())
+	info.CPU.Sys = time.Duration(rusage.Stime.Nano())
+
+	_, resident, suspend := taskInfo(task)
+	info.Memory.Available = memoryAvailable()
+	info.Memory.Size = resident
+	info.Memory.Resident = resident
+	info.Memory.MajorPageFaults = uint64(rusage.Majflt)
+	info.Memory.MinorPageFaults = uint64(rusage.Minflt)
+
+	info.Files.Max = nofile.Cur
+	info.Files.Open = fdCount(pid)
+
+	info.Threads.Num = threadCount(task)
+	info.Threads.InvoluntaryContextSwitches = suspend
 	return
 }
 
-func collectCPUInfo(pid int) (info CPUInfo, err error) {
-	// TODO
-	return
+func memoryAvailable() uint64 {
+	mib := [2]C.int{C.CTL_HW, C.HW_MEMSIZE}
+	mem := C.int64_t(0)
+	len := C.size_t(8) // sizeof(int64_t)
+
+	_, err := C.sysctl(&mib[0], 2, unsafe.Pointer(&mem), &len, nil, 0)
+	check(err)
+
+	return uint64(mem)
 }
 
-func collectMemoryInfo(pid int) (info MemoryInfo, err error) {
-	// TODO
-	return
+func taskInfo(task C.mach_port_name_t) (virtual uint64, resident uint64, suspend uint64) {
+	info := C.mach_task_basic_info_data_t{}
+	count := C.mach_msg_type_number_t(C.MACH_TASK_BASIC_INFO_COUNT)
+
+	checkKern(C.task_info(
+		C.task_name_t(task),
+		C.MACH_TASK_BASIC_INFO, (*C.integer_t)(unsafe.Pointer(&info)),
+		&count,
+	))
+
+	return uint64(info.virtual_size), uint64(info.resident_size), uint64(info.suspend_count)
 }
 
-func collectFileInfo(pid int) (info FileInfo, err error) {
-	// TODO
-	return
+func fdCount(pid int) uint64 {
+	return uint64(C.proc_pidinfo(C.int(pid), C.PROC_PIDLISTFDS, 0, 0, 0, nil)) / uint64(C.PROC_PIDLISTFD_SIZE)
 }
 
-func collectThreadInfo(pid int) (info ThreadInfo, err error) {
-	// TODO
-	return
+func threadCount(task C.mach_port_name_t) uint64 {
+	threads := make([]C.thread_act_t, 100)
+	count := C.mach_msg_type_number_t(0)
+
+	for {
+		checkKern(C.task_threads(
+			C.task_inspect_t(task),
+			(*C.thread_act_array_t)(unsafe.Pointer(&threads[0])),
+			&count,
+		))
+
+		if uint64(count) < uint64(len(threads)) {
+			break
+		}
+
+		threads = make([]C.thread_act_t, 10*len(threads))
+		count = 0
+	}
+
+	return uint64(count)
+}
+
+func checkKern(rc C.kern_return_t) {
+	if rc != C.KERN_SUCCESS {
+		panic(fmt.Errorf("mach trap kernel error code: %d", rc))
+	}
 }

--- a/procstats/proc_linux.go
+++ b/procstats/proc_linux.go
@@ -1,24 +1,29 @@
 package procstats
 
 import (
+	"os"
 	"syscall"
 	"time"
 
 	"github.com/segmentio/stats/procstats/linux"
 )
 
-func getpagesize() uint64 { return uint64(syscall.Getpagesize()) }
-
 func collectProcInfo(pid int) (info ProcInfo, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
+
+	pagesize := uint64(syscall.Getpagesize())
+	rusage := syscall.Rusage{}
+
+	if pid == os.Getpid() {
+		check(syscall.Getrusage(syscall.RUSAGE_SELF, &rusage))
+	} else {
+		// TODO: figure out how to get accurate stats for other processes
+	}
 
 	memoryLimit, err := linux.GetMemoryLimit(pid)
 	check(err)
 
 	limits, err := linux.GetProcLimits(pid)
-	check(err)
-
-	stat, err := linux.GetProcStat(pid)
 	check(err)
 
 	statm, err := linux.GetProcStatm(pid)
@@ -30,13 +35,10 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 	fds, err := linux.GetOpenFileCount(pid)
 	check(err)
 
-	pagesize := getpagesize()
-	clockTicks := getclktck()
-
 	info = ProcInfo{
 		CPU: CPUInfo{
-			User: (time.Duration(stat.Utime) * time.Nanosecond) / time.Duration(clockTicks),
-			Sys:  (time.Duration(stat.Stime) * time.Nanosecond) / time.Duration(clockTicks),
+			User: time.Duration(rusage.Utime.Nano()),
+			Sys:  time.Duration(rusage.Stime.Nano()),
 		},
 
 		Memory: MemoryInfo{
@@ -46,8 +48,8 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 			Shared:          pagesize * statm.Share,
 			Text:            pagesize * statm.Text,
 			Data:            pagesize * statm.Data,
-			MajorPageFaults: stat.Majflt,
-			MinorPageFaults: stat.Minflt,
+			MajorPageFaults: rusage.Majflt,
+			MinorPageFaults: rusage.Minflt,
 		},
 
 		Files: FileInfo{
@@ -60,81 +62,6 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 			VoluntaryContextSwitches:   sched.NRVoluntarySwitches,
 			InvoluntaryContextSwitches: sched.NRInvoluntarySwitches,
 		},
-	}
-	return
-}
-
-func collectCPUInfo(pid int) (info CPUInfo, err error) {
-	defer func() { err = convertPanicToError(recover()) }()
-
-	stat, err := linux.GetProcStat(pid)
-	check(err)
-
-	clockTicks := getclktck()
-
-	info = CPUInfo{
-		User: (time.Duration(stat.Utime) * time.Nanosecond) / time.Duration(clockTicks),
-		Sys:  (time.Duration(stat.Stime) * time.Nanosecond) / time.Duration(clockTicks),
-	}
-	return
-}
-
-func collectMemoryInfo(pid int) (info MemoryInfo, err error) {
-	defer func() { err = convertPanicToError(recover()) }()
-
-	memoryLimit, err := linux.GetMemoryLimit(pid)
-	check(err)
-
-	stat, err := linux.GetProcStat(pid)
-	check(err)
-
-	statm, err := linux.GetProcStatm(pid)
-	check(err)
-
-	pagesize := getpagesize()
-
-	info = MemoryInfo{
-		Available:       memoryLimit,
-		Size:            pagesize * statm.Size,
-		Resident:        pagesize * statm.Resident,
-		Shared:          pagesize * statm.Share,
-		Text:            pagesize * statm.Text,
-		Data:            pagesize * statm.Data,
-		MajorPageFaults: stat.Majflt,
-		MinorPageFaults: stat.Minflt,
-	}
-	return
-}
-
-func collectFileInfo(pid int) (info FileInfo, err error) {
-	defer func() { err = convertPanicToError(recover()) }()
-
-	limits, err := linux.GetProcLimits(pid)
-	check(err)
-
-	fds, err := linux.GetOpenFileCount(pid)
-	check(err)
-
-	info = FileInfo{
-		Open: fds,
-		Max:  limits.OpenFiles.Soft,
-	}
-	return
-}
-
-func collectThreadInfo(pid int) (info ThreadInfo, err error) {
-	defer func() { err = convertPanicToError(recover()) }()
-
-	stat, err := linux.GetProcStat(pid)
-	check(err)
-
-	sched, err := linux.GetProcSched(pid)
-	check(err)
-
-	info = ThreadInfo{
-		Num: uint64(stat.NumThreads),
-		VoluntaryContextSwitches:   sched.NRVoluntarySwitches,
-		InvoluntaryContextSwitches: sched.NRInvoluntarySwitches,
 	}
 	return
 }

--- a/procstats/proc_linux.go
+++ b/procstats/proc_linux.go
@@ -26,6 +26,9 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 	limits, err := linux.GetProcLimits(pid)
 	check(err)
 
+	stat, err := linux.GetProcStat(pid)
+	check(err)
+
 	statm, err := linux.GetProcStatm(pid)
 	check(err)
 
@@ -48,8 +51,8 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 			Shared:          pagesize * statm.Share,
 			Text:            pagesize * statm.Text,
 			Data:            pagesize * statm.Data,
-			MajorPageFaults: rusage.Majflt,
-			MinorPageFaults: rusage.Minflt,
+			MajorPageFaults: uint64(rusage.Majflt),
+			MinorPageFaults: uint64(rusage.Minflt),
 		},
 
 		Files: FileInfo{

--- a/procstats/proc_test.go
+++ b/procstats/proc_test.go
@@ -13,13 +13,19 @@ func TestProcMetrics(t *testing.T) {
 	e := stats.NewEngine("", h)
 
 	proc := NewProcMetricsWith(e, os.Getpid())
-	proc.Collect()
 
-	if len(h.Measures()) == 0 {
-		t.Error("no measures were reported by the stats collector")
-	}
+	for i := 0; i != 10; i++ {
+		t.Logf("collect number %d", i)
+		proc.Collect()
 
-	for _, m := range h.Measures() {
-		t.Log(m)
+		if len(h.Measures()) == 0 {
+			t.Error("no measures were reported by the stats collector")
+		}
+
+		for _, m := range h.Measures() {
+			t.Log(m)
+		}
+
+		h.Clear()
 	}
 }

--- a/procstats/proc_unix_cgo.go
+++ b/procstats/proc_unix_cgo.go
@@ -1,8 +1,0 @@
-// +build !windows
-
-package procstats
-
-// #include <unistd.h>
-import "C"
-
-func getclktck() uint64 { return uint64(C.sysconf(C._SC_CLK_TCK)) }

--- a/procstats/proc_unix_nocgo.go
+++ b/procstats/proc_unix_nocgo.go
@@ -1,5 +1,0 @@
-// +build !cgo,!windows
-
-package procstats
-
-func getclktck() uint64 { return 100 }

--- a/procstats/proc_windows.go
+++ b/procstats/proc_windows.go
@@ -4,23 +4,3 @@ func collectProcMetrics(pid int) (m proc, err error) {
 	// TODO
 	return
 }
-
-func collectCPUInfo(pid int) (info CPUInfo, err error) {
-	// TODO
-	return
-}
-
-func collectMemoryInfo(pid int) (info MemoryInfo, err error) {
-	// TODO
-	return
-}
-
-func collectFileInfo(pid int) (info FileInfo, err error) {
-	// TODO
-	return
-}
-
-func collectThreadInfo(pid int) (info ThreadInfo, err error) {
-	// TODO
-	return
-}


### PR DESCRIPTION
There are three main changes in the PR:
- Report percentage of CPU and Memory usage of the process
- Fix CPU usage values on linux by switching to use `getrusage`
- Add implementation process metrics collection on darwin

Those things are pretty hard to test because we can never predict how much resources a process is using (plus it's very dependent on the environment), here's a trace of the tests ran on OSX:
```
	proc_test.go:26: { cpu(counter:usage.seconds=46µs, gauge:usage.percent=73.76050285421076) [type=user] }
	proc_test.go:26: { cpu(counter:usage.seconds=16µs, gauge:usage.percent=25.655827079725483) [type=system] }
	proc_test.go:26: { memory(gauge:usage.bytes=2707456, gauge:usage.percent=0.03151893615722656) [type=resident] }
	proc_test.go:26: { memory(gauge:usage.bytes=0) [type=shared] }
	proc_test.go:26: { memory(gauge:usage.bytes=0) [type=text] }
	proc_test.go:26: { memory(gauge:usage.bytes=0) [type=data] }
	proc_test.go:26: { memory.pagefault(counter:count=0) [type=major] }
	proc_test.go:26: { memory.pagefault(counter:count=6) [type=minor] }
	proc_test.go:26: { memory(gauge:available.bytes=8589934592, gauge:total.bytes=2707456) [] }
	proc_test.go:26: { files(gauge:open.count=45, gauge:open.max=7168) [] }
	proc_test.go:26: { threads.switch(counter:count=0) [type=voluntary] }
	proc_test.go:26: { threads.switch(counter:count=0) [type=involuntary] }
	proc_test.go:26: { threads(gauge:count=5) [] }
```
The values seem to make sense, let me know if anything should be changed!