### PR TITLE
better GC stats

### DIFF
--- a/procstats/go_test.go
+++ b/procstats/go_test.go
@@ -1,9 +1,7 @@
 package procstats
 
 import (
-	"reflect"
 	"runtime"
-	"runtime/debug"
 	"testing"
 	"time"
 
@@ -30,60 +28,11 @@ func TestGoMetrics(t *testing.T) {
 		}
 
 		h.Clear()
-		runtime.GC()
+
+		for j := 0; j <= i; j++ {
+			runtime.GC() // to get non-zero GC stats
+		}
+
 		time.Sleep(10 * time.Millisecond)
-	}
-}
-
-func TestStripOutdatedGCPauses(t *testing.T) {
-	now := time.Now()
-
-	gc := &debug.GCStats{}
-	gc.LastGC = now.Add(-time.Second) // 1s ago
-	gc.NumGC = 10                     // 10th GC pass
-	gc.PauseTotal = time.Millisecond  // 1ms pauses total
-	gc.Pause = []time.Duration{
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-		100 * time.Microsecond,
-	}
-	gc.PauseEnd = []time.Time{
-		now.Add(-time.Second).Add(-100 * time.Microsecond),
-		now.Add(-time.Second).Add(-200 * time.Microsecond),
-		now.Add(-time.Second).Add(-300 * time.Microsecond),
-		now.Add(-time.Second).Add(-400 * time.Microsecond),
-		now.Add(-time.Second).Add(-500 * time.Microsecond),
-		now.Add(-time.Second).Add(-600 * time.Microsecond),
-		now.Add(-time.Second).Add(-700 * time.Microsecond),
-		now.Add(-time.Second).Add(-800 * time.Microsecond),
-		now.Add(-time.Second).Add(-900 * time.Microsecond),
-		now.Add(-time.Second).Add(-1 * time.Millisecond),
-	}
-
-	gc.PauseQuantiles = nil // ???
-
-	stripOutdatedGCPauses(gc, 8) // last observed the 8th pass
-
-	if !reflect.DeepEqual(gc, &debug.GCStats{
-		LastGC:     now.Add(-time.Second),
-		NumGC:      10,
-		PauseTotal: time.Millisecond,
-		Pause: []time.Duration{
-			100 * time.Microsecond,
-			100 * time.Microsecond,
-		},
-		PauseEnd: []time.Time{
-			now.Add(-time.Second).Add(-100 * time.Microsecond),
-			now.Add(-time.Second).Add(-200 * time.Microsecond),
-		},
-	}) {
-		t.Errorf("invalid gc stats after stripping outdated pauses:\n%#v", *gc)
 	}
 }


### PR DESCRIPTION
I noticed GC stats seemed inflated in some cases, the logic for stripping out outdated GC stats seemed hard to debug and error prone, so I replaced it to use the values in the `runtime.MemStats` structure.

This also makes the GC stats collection more efficient as it doesn't require calling `debug.ReadGCStats` anymore.

I based most of this work on the `runtime.MemStats` [documentation](https://golang.org/pkg/runtime/#MemStats).

Here's a trace of the test showing GC stats computation:
```
=== RUN   TestGoMetrics
--- PASS: TestGoMetrics (0.11s)
	go_test.go:19: collect number 0
	go_test.go:27: { go.runtime(gauge:cpu.num=4, gauge:goroutine.num=2, counter:cgo.calls=1) [version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=332560, counter:total_alloc.bytes=332560, counter:lookups.count=3, counter:mallocs.count=2718, counter:frees.count=253) [type=total, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=332560, gauge:sys.bytes=1769472, gauge:idle.bytes=909312, gauge:inuse.bytes=860160, counter:released.bytes=0, gauge:objects.count=2465) [type=heap, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=327680, gauge:sys.bytes=327680) [type=stack, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=13528, gauge:sys.bytes=16384) [type=mspan, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=6944, gauge:sys.bytes=16384) [type=mcache, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=2345) [type=bucket_hash_table, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=137216) [type=gc, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=814807) [type=other, version=go1.9] }
	go_test.go:27: { go.memstats(counter:gc.count=0, gauge:gc_next.bytes=4473924, gauge:gc_pause.seconds.avg=0s, gauge:gc_pause.seconds.min=0s, gauge:gc_pause.seconds.max=0s, gauge:gc_cpu.fraction=0) [version=go1.9] }
	go_test.go:19: collect number 1
	go_test.go:27: { go.runtime(gauge:cpu.num=4, gauge:goroutine.num=2, counter:cgo.calls=0) [version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=87528, counter:total_alloc.bytes=33120, counter:lookups.count=0, counter:mallocs.count=573, counter:frees.count=2649) [type=total, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=87528, gauge:sys.bytes=1736704, gauge:idle.bytes=1228800, gauge:inuse.bytes=507904, counter:released.bytes=0, gauge:objects.count=389) [type=heap, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=360448, gauge:sys.bytes=360448) [type=stack, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=10336, gauge:sys.bytes=16384) [type=mspan, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=6944, gauge:sys.bytes=16384) [type=mcache, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=2345) [type=bucket_hash_table, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=274432) [type=gc, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=808663) [type=other, version=go1.9] }
	go_test.go:27: { go.memstats(counter:gc.count=1, gauge:gc_next.bytes=4194304, gauge:gc_pause.seconds.avg=52.508µs, gauge:gc_pause.seconds.min=52.508µs, gauge:gc_pause.seconds.max=52.508µs, gauge:gc_cpu.fraction=-3.678665601751283e-11) [version=go1.9] }
	go_test.go:19: collect number 2
	go_test.go:27: { go.runtime(gauge:cpu.num=4, gauge:goroutine.num=2, counter:cgo.calls=0) [version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=89160, counter:total_alloc.bytes=28312, counter:lookups.count=0, counter:mallocs.count=263, counter:frees.count=265) [type=total, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:alloc.bytes=89160, gauge:sys.bytes=1736704, gauge:idle.bytes=1220608, gauge:inuse.bytes=516096, counter:released.bytes=0, gauge:objects.count=387) [type=heap, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=360448, gauge:sys.bytes=360448) [type=stack, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=10488, gauge:sys.bytes=16384) [type=mspan, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:inuse.bytes=6944, gauge:sys.bytes=16384) [type=mcache, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=2345) [type=bucket_hash_table, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=274432) [type=gc, version=go1.9] }
	go_test.go:27: { go.memstats(gauge:sys.bytes=808663) [type=other, version=go1.9] }
	go_test.go:27: { go.memstats(counter:gc.count=2, gauge:gc_next.bytes=4194304, gauge:gc_pause.seconds.avg=12.01µs, gauge:gc_pause.seconds.min=11.511µs, gauge:gc_pause.seconds.max=12.509µs, gauge:gc_cpu.fraction=-7.030487196218036e-11) [version=go1.9] }
```

Please take a look and let me know if something should be changed.