### PR TITLE
Zero allocations for SortTags

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -39,9 +39,13 @@ func TagsAreSorted(tags []Tag) bool {
 
 // SortTags sorts the slice of tags.
 func SortTags(tags []Tag) []Tag {
-	// TODO: optimize to get rid of the dynamic memory allocation required
-	// to construct the interface value.
-	sort.Sort(tagsByName(tags))
+	// Insertion sort since these arrays are very small and allocation is the
+	// primary enemy of performance here.
+	for i := 0; i < len(tags); i++ {
+		for j := i; j > 0 && tags[j-1].Name > tags[j].Name; j-- {
+			tags[j], tags[j-1] = tags[j-1], tags[j]
+		}
+	}
 	return tags
 }
 

--- a/tag.go
+++ b/tag.go
@@ -41,9 +41,13 @@ func TagsAreSorted(tags []Tag) bool {
 func SortTags(tags []Tag) []Tag {
 	// Insertion sort since these arrays are very small and allocation is the
 	// primary enemy of performance here.
-	for i := 0; i < len(tags); i++ {
-		for j := i; j > 0 && tags[j-1].Name > tags[j].Name; j-- {
-			tags[j], tags[j-1] = tags[j-1], tags[j]
+	if len(tags) >= 20 {
+		sort.Sort(tagsByName(tags))
+	} else {
+		for i := 0; i < len(tags); i++ {
+			for j := i; j > 0 && tags[j-1].Name > tags[j].Name; j-- {
+				tags[j], tags[j-1] = tags[j-1], tags[j]
+			}
 		}
 	}
 	return tags

--- a/tag_test.go
+++ b/tag_test.go
@@ -152,3 +152,36 @@ func BenchmarkSortTags(b *testing.B) {
 		SortTags(t1)
 	}
 }
+
+func BenchmarkSortTagsMany(b *testing.B) {
+	t0 := []Tag{
+		{"hello", "world"},
+		{"answer", "42"},
+		{"some long tag name", "!"},
+		{"some longer tag name", "1234"},
+		{"A", ""},
+		{"B", ""},
+		{"C", ""},
+		{"hello", "world"},
+		{"answer", "42"},
+		{"some long tag name", "!"},
+		{"some longer tag name", "1234"},
+		{"A", ""},
+		{"B", ""},
+		{"C", ""},
+		{"hello", "world"},
+		{"answer", "42"},
+		{"some long tag name", "!"},
+		{"some longer tag name", "1234"},
+		{"A", ""},
+		{"B", ""},
+		{"C", ""},
+	}
+
+	t1 := make([]Tag, len(t0))
+
+	for i := 0; i != b.N; i++ {
+		copy(t1, t0)
+		SortTags(t1)
+	}
+}


### PR DESCRIPTION
This was causing a large number of allocations since it needs to be called for every stats call, which can be VERY frequent. This patch also cuts the cost of SortTags in half.

Before:
BenchmarkSortTags-2      5000000               337 ns/op              32 B/op          1 allocs/op

After:
BenchmarkSortTags-2     10000000               198 ns/op               0 B/op          0 allocs/op