### PR TITLE
Use mutex instead of atomic operations

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -3,9 +3,7 @@ package stats
 import (
 	"io"
 	"sync"
-	"sync/atomic"
 	"time"
-	"unsafe"
 )
 
 // Buffer is the implementation of a measure handler which uses a Serializer to
@@ -28,114 +26,71 @@ type Buffer struct {
 	// This field cannot be nil.
 	Serializer Serializer
 
-	buffer unsafe.Pointer
-	join   sync.WaitGroup
+	mutex  sync.Mutex
+	buffer *buffer
 }
 
 // HandleMeasures satisfies the Handler interface.
-func (h *Buffer) HandleMeasures(time time.Time, measures ...Measure) {
+func (b *Buffer) HandleMeasures(time time.Time, measures ...Measure) {
 	if len(measures) == 0 {
 		return
 	}
 
-	size := h.BufferSize
+	size := b.BufferSize
 	if size == 0 {
 		size = 1024
 	}
 
-	c := chunkPool.Get().(*chunk)
-	c.b = h.Serializer.AppendMeasures(c.b[:0], time, measures...)
-	l := int32(len(c.b))
+	chunk := acquireChunk()
+	chunk.reset()
+	chunk.append(b.Serializer, time, measures...)
 
 	// Chunks that are already larger than the maximum buffer size are directly
 	// passed to the serializer, no need to aggregate them in a larger buffer.
-	if int(l) >= size {
-		h.join.Add(1)
-		go h.writeChunk(c)
-		return
-	}
+	if chunk.len() >= size {
+		chunk.writeTo(b.Serializer)
+	} else {
+		for {
+			var flush *buffer
 
-	for {
-		b := h.loadBuffer()
+			b.mutex.Lock()
 
-		if b == nil {
-			b = bufferPool.Get().(*buffer)
-			b.init(size)
-
-			if !h.compareAndSwapBuffer(nil, b) {
-				bufferPool.Put(b)
-				continue
+			if b.buffer == nil {
+				b.buffer = acquireBuffer()
+				b.buffer.reset(size)
 			}
-		}
 
-		b.m.RLock()
-		m := int32(len(b.b))
-		n := atomic.AddInt32(&b.n, l)
+			if (b.buffer.len() + chunk.len()) > b.buffer.cap() {
+				b.buffer, flush = nil, b.buffer
+			} else {
+				b.buffer.append(chunk)
+			}
 
-		if n >= 0 && n <= m {
-			copy(b.b[n-l:n], c.b)
-			b.m.RUnlock()
-			break
-		}
+			b.mutex.Unlock()
 
-		b.m.RUnlock()
+			if flush == nil {
+				break
+			}
 
-		if n < 0 || (n-l) > m {
-			// Only the goroutine that first overflows the buffer size is in
-			// charge of writing the buffer, the others go back and try to
-			// acquire a new one to copy their measures into.
-			continue
-		}
-
-		if h.compareAndSwapBuffer(b, nil) {
-			b.waitReleaseRLock()
-			h.join.Add(1)
-			go h.writeBuffer(b, int(n-l))
+			flush.writeTo(b.Serializer)
+			releaseBuffer(flush)
 		}
 	}
 
-	chunkPool.Put(c)
+	releaseChunk(chunk)
 }
 
 // Flush satisfies the Flusher interface.
-func (h *Buffer) Flush() {
-	for {
-		b := h.loadBuffer()
-		if b == nil {
-			break
-		}
-		if h.compareAndSwapBuffer(b, nil) {
-			n := b.waitReleaseRLockAndFinalize()
-			if n <= len(b.b) {
-				h.join.Add(1)
-				go h.writeBuffer(b, n)
-			}
-		}
+func (b *Buffer) Flush() {
+	b.mutex.Lock()
+
+	if buffer := b.buffer; buffer != nil {
+		b.buffer = nil
+		buffer.writeTo(b.Serializer)
+		releaseBuffer(buffer)
 	}
-	h.join.Wait()
-}
 
-func (h *Buffer) loadBuffer() *buffer {
-	return (*buffer)(atomic.LoadPointer(&h.buffer))
-}
-
-func (h *Buffer) compareAndSwapBuffer(old *buffer, new *buffer) bool {
-	return atomic.CompareAndSwapPointer(&h.buffer,
-		unsafe.Pointer(old),
-		unsafe.Pointer(new),
-	)
-}
-
-func (h *Buffer) writeBuffer(b *buffer, n int) {
-	h.Serializer.Write(b.b[:n])
-	h.join.Done()
-	bufferPool.Put(b)
-}
-
-func (h *Buffer) writeChunk(c *chunk) {
-	h.Serializer.Write(c.b)
-	h.join.Done()
-	chunkPool.Put(c)
+	b.mutex.Unlock()
 }
 
 // The Serializer interface is used to abstract the logic of serializing
@@ -151,35 +106,50 @@ type Serializer interface {
 
 type buffer struct {
 	b []byte
-	m sync.RWMutex
-	n int32
 }
 
-func (buf *buffer) init(size int) {
-	buf.m.Lock()
+func (buf *buffer) reset(size int) {
 	if cap(buf.b) < size {
 		buf.b = make([]byte, 0, size)
+	} else {
+		buf.b = buf.b[:0]
 	}
-	buf.b = buf.b[:size]
-	buf.n = 0
-	buf.m.Unlock()
 }
 
-func (buf *buffer) waitReleaseRLock() {
-	buf.m.Lock()
-	buf.m.Unlock()
+func (buf *buffer) append(c *chunk) {
+	buf.b = append(buf.b, c.b...)
 }
 
-func (buf *buffer) waitReleaseRLockAndFinalize() int {
-	buf.m.Lock()
-	n := buf.n
-	buf.n = int32(len(buf.b))
-	buf.m.Unlock()
-	return int(n)
+func (buf *buffer) len() int {
+	return len(buf.b)
+}
+
+func (buf *buffer) cap() int {
+	return cap(buf.b)
+}
+
+func (buf *buffer) writeTo(w io.Writer) {
+	w.Write(buf.b)
 }
 
 type chunk struct {
 	b []byte
+}
+
+func (c *chunk) reset() {
+	c.b = c.b[:0]
+}
+
+func (c *chunk) append(s Serializer, t time.Time, m ...Measure) {
+	c.b = s.AppendMeasures(c.b, t, m...)
+}
+
+func (c *chunk) len() int {
+	return len(c.b)
+}
+
+func (c *chunk) writeTo(w io.Writer) {
+	w.Write(c.b)
 }
 
 var bufferPool = sync.Pool{
@@ -189,3 +159,9 @@ var bufferPool = sync.Pool{
 var chunkPool = sync.Pool{
 	New: func() interface{} { return &chunk{b: make([]byte, 1024)} },
 }
+
+func acquireBuffer() *buffer  { return bufferPool.Get().(*buffer) }
+func releaseBuffer(b *buffer) { bufferPool.Put(b) }
+
+func acquireChunk() *chunk  { return chunkPool.Get().(*chunk) }
+func releaseChunk(c *chunk) { chunkPool.Put(c) }

--- a/datadog/client.go
+++ b/datadog/client.go
@@ -73,6 +73,7 @@ func NewClientWith(config ClientConfig) *Client {
 	c.conn, c.err, c.bufferSize = conn, err, bufferSize
 	c.buffer.BufferSize = bufferSize
 	c.buffer.Serializer = &c.serializer
+	log.Printf("stats/datadog: sending metrics with a buffer of size %d B", bufferSize)
 	return c
 }
 


### PR DESCRIPTION
This PR makes to main changes:
- Change the use of atomic operations in favor of mutexes, testing with Go 1.9 there's almost no different anymore, definitely good improvements have been made to the mutex implementation, so I'd rather have an implementation that's easier to read and reason about.
- Don't spawn new goroutines to flush the measures. This was actually causing pretty high contention on the goroutine scheduler on a very high traffic service that was producing a lot of metrics.