### PR TITLE
stats/prometheus/handler.go: fix typo

### DIFF
--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -113,7 +113,7 @@ func (h *Handler) timeout() time.Duration {
 	return 2 * time.Minute
 }
 
-// ServeHTTP satsifies the http.Handler interface.
+// ServeHTTP satisfies the http.Handler interface.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET", "HEAD":


### PR DESCRIPTION
Just a small typo "satsifies" -> "satisfies"