### PR TITLE
added an option to add the request path as a tag

### DIFF
--- a/datadog/append.go
+++ b/datadog/append.go
@@ -33,14 +33,6 @@ func appendMetric(b []byte, m Metric) []byte {
 
 func appendTags(b []byte, tags []stats.Tag) []byte {
 	for i, t := range tags {
-		if t.Name == "http_req_path" {
-			// Datadog has complained numerous times that the request paths
-			// generate too many custom metrics on their side, for now we'll
-			// simply strip it out until we can come up with a better strategy
-			// for handling those.
-			continue
-		}
-
 		if i != 0 {
 			b = append(b, ',')
 		}

--- a/datadog/measure.go
+++ b/datadog/measure.go
@@ -9,7 +9,7 @@ import (
 
 // AppendMeasure is a formatting routine to append the dogstatsd protocol
 // representation of a measure to a memory buffer.
-func AppendMeasure(b []byte, m stats.Measure) []byte {
+func AppendMeasure(b []byte, m stats.Measure, filters map[string]struct{}) []byte {
 	for _, field := range m.Fields {
 		b = append(b, m.Name...)
 		if len(field.Name) != 0 {
@@ -50,12 +50,14 @@ func AppendMeasure(b []byte, m stats.Measure) []byte {
 			b = append(b, '|', '#')
 
 			for i, t := range m.Tags {
-				if i != 0 {
-					b = append(b, ',')
+				if _, ok := filters[t.Name]; !ok {
+					if i != 0 {
+						b = append(b, ',')
+					}
+					b = append(b, t.Name...)
+					b = append(b, ':')
+					b = append(b, t.Value...)
 				}
-				b = append(b, t.Name...)
-				b = append(b, ':')
-				b = append(b, t.Value...)
 			}
 		}
 

--- a/datadog/measure.go
+++ b/datadog/measure.go
@@ -9,7 +9,14 @@ import (
 
 // AppendMeasure is a formatting routine to append the dogstatsd protocol
 // representation of a measure to a memory buffer.
-func AppendMeasure(b []byte, m stats.Measure, filters map[string]struct{}) []byte {
+func AppendMeasure(b []byte, m stats.Measure) []byte {
+	return AppendMeasureFiltered(b, m, nil)
+}
+
+// AppendMeasureFiltered is a formatting routine to append the dogstatsd protocol
+// representation of a measure to a memory buffer. Tags listed in the filters map
+// are removed. (some tags may not be suitable for submission to DataDog)
+func AppendMeasureFiltered(b []byte, m stats.Measure, filters map[string]struct{}) []byte {
 	for _, field := range m.Fields {
 		b = append(b, m.Name...)
 		if len(field.Name) != 0 {

--- a/datadog/measure_test.go
+++ b/datadog/measure_test.go
@@ -45,7 +45,7 @@ request.rtt:0.1|h|#answer:42,hello:world
 func TestAppendMeasure(t *testing.T) {
 	for _, test := range testMeasures {
 		t.Run(test.s, func(t *testing.T) {
-			if s := string(AppendMeasure(nil, test.m)); s != test.s {
+			if s := string(AppendMeasure(nil, test.m, nil)); s != test.s {
 				t.Error("bad metric representation:")
 				t.Log("expected:", test.s)
 				t.Log("found:   ", s)

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -171,6 +171,7 @@ type metrics struct {
 		contentType      string `tag:"http_req_content_type"`
 		host             string `tag:"http_req_host"`
 		method           string `tag:"http_req_method"`
+		path             string `tag:"http_req_path"`
 		protocol         string `tag:"http_req_protocol"`
 		transferEncoding string `tag:"http_req_transfer_encoding"`
 	} `metric:"http"`
@@ -197,6 +198,13 @@ func (m *metrics) observeRequest(req *http.Request, op string, bodyLen int) {
 	m.http.method = req.Method
 	m.http.protocol = req.Proto
 	m.http.transferEncoding = transferEncoding
+
+	path := req.URL.Path
+
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	m.http.path = path
 }
 
 func (m *metrics) observeResponse(res *http.Response, op string, bodyLen int, rtt time.Duration) {


### PR DESCRIPTION
Creates a new constructor for Handler that will include the request path as a DataDog tag. Also removes filter for the `http_req_path` tag that was used to limit requests to DataDog.