### PR TITLE
wait-free buffer

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -57,7 +57,10 @@ func (b *Buffer) HandleMeasures(time time.Time, measures ...Measure) {
 			break
 		}
 
-		buffer.trimTo(length)
+		if length != 0 {
+			buffer.trimTo(length)
+		}
+
 		buffer.writeTo(b.Serializer)
 		buffer.reset()
 		buffer.release()

--- a/buffer.go
+++ b/buffer.go
@@ -2,7 +2,9 @@ package stats
 
 import (
 	"io"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,13 +23,19 @@ type Buffer struct {
 	// decision of accepting or rejecting the metrics.
 	BufferSize int
 
+	// Size of the internal buffer pool, this controls how well the buffer
+	// performs in highly concurrent environments. If unset, 2 x GOMAXPROCS
+	// is used as a default value.
+	BufferPoolSize int
+
 	// The Serializer used to write the measures.
 	//
 	// This field cannot be nil.
 	Serializer Serializer
 
-	mutex  sync.Mutex
-	buffer *buffer
+	once    sync.Once
+	offset  uint64
+	buffers []buffer
 }
 
 // HandleMeasures satisfies the Handler interface.
@@ -36,61 +44,71 @@ func (b *Buffer) HandleMeasures(time time.Time, measures ...Measure) {
 		return
 	}
 
-	size := b.BufferSize
-	if size == 0 {
-		size = 1024
-	}
+	size := b.bufferSize()
+	b.init(size)
 
-	chunk := acquireChunk()
-	chunk.reset()
-	chunk.append(b.Serializer, time, measures...)
+	for {
+		buffer := b.acquireBuffer()
+		length := buffer.len()
+		buffer.append(b.Serializer, time, measures...)
 
-	// Chunks that are already larger than the maximum buffer size are directly
-	// passed to the serializer, no need to aggregate them in a larger buffer.
-	if chunk.len() >= size {
-		chunk.writeTo(b.Serializer)
-	} else {
-		for {
-			var flush *buffer
-
-			b.mutex.Lock()
-
-			if b.buffer == nil {
-				b.buffer = acquireBuffer()
-				b.buffer.reset(size)
-			}
-
-			if (b.buffer.len() + chunk.len()) > b.buffer.cap() {
-				b.buffer, flush = nil, b.buffer
-			} else {
-				b.buffer.append(chunk)
-			}
-
-			b.mutex.Unlock()
-
-			if flush == nil {
-				break
-			}
-
-			flush.writeTo(b.Serializer)
-			releaseBuffer(flush)
+		if buffer.len() < size {
+			buffer.release()
+			break
 		}
-	}
 
-	releaseChunk(chunk)
+		buffer.trimTo(length)
+		buffer.writeTo(b.Serializer)
+		buffer.reset()
+		buffer.release()
+	}
 }
 
 // Flush satisfies the Flusher interface.
 func (b *Buffer) Flush() {
-	b.mutex.Lock()
+	b.init(b.bufferSize())
 
-	if buffer := b.buffer; buffer != nil {
-		b.buffer = nil
-		buffer.writeTo(b.Serializer)
-		releaseBuffer(buffer)
+	for i := range b.buffers {
+		if buffer := &b.buffers[i]; buffer.acquire() {
+			buffer.writeTo(b.Serializer)
+			buffer.reset()
+			buffer.release()
+		}
 	}
+}
 
-	b.mutex.Unlock()
+func (b *Buffer) init(bufferSize int) {
+	b.once.Do(func() {
+		b.buffers = make([]buffer, b.bufferPoolSize())
+		for i := range b.buffers {
+			b.buffers[i].init(bufferSize)
+		}
+	})
+}
+
+func (b *Buffer) bufferSize() int {
+	if b.BufferSize != 0 {
+		return b.BufferSize
+	}
+	return 1024
+}
+
+func (b *Buffer) bufferPoolSize() int {
+	if b.BufferPoolSize != 0 {
+		return b.BufferPoolSize
+	}
+	return 2 * runtime.GOMAXPROCS(0)
+}
+
+func (b *Buffer) acquireBuffer() *buffer {
+	for {
+		offset := int(atomic.AddUint64(&b.offset, 1) % uint64(len(b.buffers)))
+		buffer := &b.buffers[offset]
+
+		if buffer.acquire() {
+			return buffer
+		}
+	}
 }
 
 // The Serializer interface is used to abstract the logic of serializing
@@ -105,63 +123,43 @@ type Serializer interface {
 }
 
 type buffer struct {
-	b []byte
+	lock uint64
+	data []byte
+	pad  [32]byte // padding to avoid false sharing between threads
 }
 
-func (buf *buffer) reset(size int) {
-	if cap(buf.b) < size {
-		buf.b = make([]byte, 0, size)
-	} else {
-		buf.b = buf.b[:0]
-	}
+func (b *buffer) acquire() bool {
+	return atomic.CompareAndSwapUint64(&b.lock, 0, 1)
 }
 
-func (buf *buffer) append(c *chunk) {
-	buf.b = append(buf.b, c.b...)
+func (b *buffer) release() {
+	atomic.StoreUint64(&b.lock, 0)
 }
 
-func (buf *buffer) len() int {
-	return len(buf.b)
+func (b *buffer) init(size int) {
+	b.data = make([]byte, 0, size+(size/4))
 }
 
-func (buf *buffer) cap() int {
-	return cap(buf.b)
+func (b *buffer) reset() {
+	b.data = b.data[:0]
 }
 
-func (buf *buffer) writeTo(w io.Writer) {
-	w.Write(buf.b)
+func (b *buffer) append(s Serializer, t time.Time, m ...Measure) {
+	b.data = s.AppendMeasures(b.data, t, m...)
 }
 
-type chunk struct {
-	b []byte
+func (b *buffer) len() int {
+	return len(b.data)
 }
 
-func (c *chunk) reset() {
-	c.b = c.b[:0]
+func (b *buffer) cap() int {
+	return cap(b.data)
 }
 
-func (c *chunk) append(s Serializer, t time.Time, m ...Measure) {
-	c.b = s.AppendMeasures(c.b, t, m...)
+func (b *buffer) writeTo(w io.Writer) {
+	w.Write(b.data)
 }
 
-func (c *chunk) len() int {
-	return len(c.b)
+func (b *buffer) trimTo(n int) {
+	b.data = b.data[:n]
 }
-
-func (c *chunk) writeTo(w io.Writer) {
-	w.Write(c.b)
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} { return &buffer{} },
-}
-
-var chunkPool = sync.Pool{
-	New: func() interface{} { return &chunk{b: make([]byte, 1024)} },
-}
-
-func acquireBuffer() *buffer  { return bufferPool.Get().(*buffer) }
-func releaseBuffer(b *buffer) { bufferPool.Put(b) }
-
-func acquireChunk() *chunk  { return chunkPool.Get().(*chunk) }
-func releaseChunk(c *chunk) { chunkPool.Put(c) }

--- a/buffer.go
+++ b/buffer.go
@@ -101,12 +101,19 @@ func (b *Buffer) bufferPoolSize() int {
 }
 
 func (b *Buffer) acquireBuffer() *buffer {
+	i := uint64(0)
+	n := uint64(len(b.buffers))
+
 	for {
-		offset := int(atomic.AddUint64(&b.offset, 1) % uint64(len(b.buffers)))
+		offset := atomic.AddUint64(&b.offset, 1) % n
 		buffer := &b.buffers[offset]
 
 		if buffer.acquire() {
 			return buffer
+		}
+
+		if i++; (i % n) == 0 {
+			runtime.Gosched()
 		}
 	}
 }

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -2,6 +2,8 @@ package datadog
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -68,6 +70,8 @@ main.http.rtt.seconds:0.001215296|h|#http_req_content_charset:,http_req_content_
 }
 
 func BenchmarkClient(b *testing.B) {
+	log.SetOutput(ioutil.Discard)
+
 	for _, N := range []int{1, 10, 100} {
 		b.Run(fmt.Sprintf("write a batch of %d measures to a client", N), func(b *testing.B) {
 			client := NewClientWith(ClientConfig{


### PR DESCRIPTION
This PR changes the approach taken to handle concurrent use of a stats buffer to get rid of all locks and offer better throughput in highly concurrent environments. What motivated this change is an observation that on an high-traffic service, 50% of the time spent in locking/unlocking was on the mutexes in the `stats.(*Buffer).HandleMeasures` method (see profile attached).

The proposed solution here is to use an array of buffers instead of a single buffer, with a wait-free lock on each buffer that goroutines have to acquire before writing metrics. They don't block on the lock tho so if a buffer is busy they'll just move to try the next one until one becomes available.

The initial chunks to which metrics were serialized is gone as well, because sync.Pool has an internal mutex which happens to hit frequently when GC is configured to be more aggressive.

I'll be testing this in production before merging it but please take a look and let me know if anything should be changed.

![screen shot 2017-10-30 at 6 28 47 pm](https://user-images.githubusercontent.com/865510/32205482-ae49bc52-bdac-11e7-85d8-25306c850353.png)
