### PR TITLE
cleanup procstats

### DIFF
--- a/procstats/collector.go
+++ b/procstats/collector.go
@@ -49,6 +49,7 @@ func StartCollectorWith(config Config) io.Closer {
 		defer close(join)
 
 		ticker := time.NewTicker(config.CollectInterval)
+		config.Collector.Collect()
 		for {
 			select {
 			case <-ticker.C:

--- a/procstats/collector.go
+++ b/procstats/collector.go
@@ -42,20 +42,18 @@ func StartCollectorWith(config Config) io.Closer {
 		// Locks the OS thread, stats collection heavily relies on blocking
 		// syscalls, letting other goroutines execute on the same thread
 		// increases the chance for the Go runtime to detected that the thread
-		// is blocked an schedule a new one.
+		// is blocked and schedule a new one.
 		runtime.LockOSThread()
 
 		defer runtime.UnlockOSThread()
 		defer close(join)
 
 		ticker := time.NewTicker(config.CollectInterval)
-
 		for {
 			select {
 			case <-ticker.C:
 				config.Collector.Collect()
 			case <-stop:
-				config.Collector.Collect()
 				return
 			}
 		}
@@ -66,7 +64,7 @@ func StartCollectorWith(config Config) io.Closer {
 
 func setConfigDefaults(config Config) Config {
 	if config.CollectInterval == 0 {
-		config.CollectInterval = 5 * time.Second
+		config.CollectInterval = 15 * time.Second
 	}
 
 	if config.Collector == nil {


### PR DESCRIPTION
Quick cleanup:
- Fix a typo
- Don't collect process stats right before stopping, it causes inflated CPU usage to be reported
- Collect CPU stats every 15 seconds, doing it every 5 seconds also causes undesirable spiky stats
