### PR TITLE
global measure cache

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -28,8 +28,6 @@ type Engine struct {
 	// helper methods WithPrefix, WithTags and the NewEngine function. A program
 	// that manipulates this field directly has to respect this requirement.
 	Tags []Tag
-
-	cache measureCache
 }
 
 // NewEngine creates and returns a new engine configured with prefix, handler,
@@ -171,7 +169,7 @@ func (eng *Engine) ReportAt(time time.Time, metrics interface{}, tags ...Tag) {
 	}
 
 	mb := measurePool.Get().(*measuresBuffer)
-	mb.measures = appendMeasures(mb.measures[:0], &eng.cache, eng.Prefix, reflect.ValueOf(metrics), tags...)
+	mb.measures = appendMeasures(mb.measures[:0], eng.Prefix, reflect.ValueOf(metrics), tags...)
 
 	ms := mb.measures
 	eng.Handler.HandleMeasures(time, ms...)

--- a/measure.go
+++ b/measure.go
@@ -79,14 +79,14 @@ func MakeMeasures(prefix string, value interface{}, tags ...Tag) []Measure {
 	if !TagsAreSorted(tags) {
 		SortTags(tags)
 	}
-	return makeMeasures(nil, prefix, reflect.ValueOf(value), tags...)
+	return makeMeasures(prefix, reflect.ValueOf(value), tags...)
 }
 
-func makeMeasures(cache *measureCache, prefix string, value reflect.Value, tags ...Tag) []Measure {
-	return appendMeasures(nil, cache, prefix, value, tags...)
+func makeMeasures(prefix string, value reflect.Value, tags ...Tag) []Measure {
+	return appendMeasures(nil, prefix, value, tags...)
 }
 
-func appendMeasures(m []Measure, cache *measureCache, prefix string, v reflect.Value, tags ...Tag) []Measure {
+func appendMeasures(m []Measure, prefix string, v reflect.Value, tags ...Tag) []Measure {
 	var p reflect.Value
 	// The optimized routines for generating Measure values need to have the
 	// address of the value, which means it has to be addressable. In the event
@@ -106,25 +106,18 @@ func appendMeasures(m []Measure, cache *measureCache, prefix string, v reflect.V
 	switch v.Kind() {
 	case reflect.Array, reflect.Slice:
 		for i, n := 0, v.Len(); i != n; i++ {
-			m = appendMeasures(m, cache, prefix, v.Index(i), tags...)
+			m = appendMeasures(m, prefix, v.Index(i), tags...)
 		}
 		return m
 	}
 
-	var ptr = unsafe.Pointer(p.Pointer())
-	var typ = v.Type()
-	var mf []measureFuncs
-	var ok bool
+	ptr := unsafe.Pointer(p.Pointer())
+	typ := v.Type()
 
-	if cache != nil {
-		mf, ok = cache.lookup(typ)
-	}
-
+	mf, ok := cache.lookup(typ)
 	if !ok {
 		mf = makeMeasureFuncs(typ, prefix)
-		if cache != nil {
-			cache.set(typ, mf)
-		}
+		cache.set(typ, mf)
 	}
 
 	used := len(m)
@@ -459,6 +452,8 @@ var measurePool = sync.Pool{
 type measureCache struct {
 	cache unsafe.Pointer
 }
+
+var cache measureCache
 
 func (c *measureCache) lookup(typ reflect.Type) ([]measureFuncs, bool) {
 	m := c.load()


### PR DESCRIPTION
The measure cache was previously kept in the engine, which had a few disadvantages:
- it caused escape analysis to always put the engine value on the heap, because internally stats.(*Engine).ReportAt would take the address of the cache, making the creation of short-lived engines quite expensive
- new engines would not share the cache from the engine they were created from, which means they would have to rebuild it on their own, making the program slower when creating short-lived engines

This PR changes the implementation to use a global cache instead, which is shared by all stat engines.