### PR TITLE
Datadog events

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -113,9 +113,17 @@ func server(args ...string) {
 	fset.Parse(args)
 	log.Printf("listening for incoming UDP datagram on %s", bind)
 
-	datadog.ListenAndServe(bind, datadog.HandlerFunc(func(metric datadog.Metric, from net.Addr) {
-		log.Print(metric)
-	}))
+	datadog.ListenAndServe(bind, handlers{})
+}
+
+type handlers struct{}
+
+func (h handlers) HandleMetric(m datadog.Metric, a net.Addr) {
+	log.Print(m)
+}
+
+func (h handlers) HandleEvent(e datadog.Event, a net.Addr) {
+	log.Print(e)
 }
 
 func run(args ...string) {

--- a/datadog/append.go
+++ b/datadog/append.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/segmentio/stats"
 )
@@ -26,6 +27,55 @@ func appendMetric(b []byte, m Metric) []byte {
 	if n := len(m.Tags); n != 0 {
 		b = append(b, '|', '#')
 		b = appendTags(b, m.Tags)
+	}
+
+	return append(b, '\n')
+}
+
+func appendEvent(b []byte, e Event) []byte {
+	b = append(b, '_', 'e', '{')
+	b = strconv.AppendInt(b, int64(len(e.Title)), 10)
+	b = append(b, ',')
+	b = strconv.AppendInt(b, int64(len(e.Text)), 10)
+	b = append(b, '}', ':')
+	b = append(b, e.Title...)
+	b = append(b, '|')
+
+	b = append(b, strings.Replace(e.Text, "\n", "\\n", -1)...)
+
+	if e.Priority != EventPriorityNormal {
+		b = append(b, '|', 'p', ':')
+		b = append(b, e.Priority...)
+	}
+
+	if e.AlertType != EventAlertTypeInfo {
+		b = append(b, '|', 't', ':')
+		b = append(b, e.AlertType...)
+	}
+
+	if e.Ts != int64(0) {
+		b = append(b, '|', 'd', ':')
+		b = strconv.AppendInt(b, e.Ts, 10)
+	}
+
+	if len(e.Host) > 0 {
+		b = append(b, '|', 'h', ':')
+		b = append(b, e.Host...)
+	}
+
+	if len(e.AggregationKey) > 0 {
+		b = append(b, '|', 'k', ':')
+		b = append(b, e.AggregationKey...)
+	}
+
+	if len(e.SourceTypeName) > 0 {
+		b = append(b, '|', 's', ':')
+		b = append(b, e.SourceTypeName...)
+	}
+
+	if n := len(e.Tags); n != 0 {
+		b = append(b, '|', '#')
+		b = appendTags(b, e.Tags)
 	}
 
 	return append(b, '\n')

--- a/datadog/event.go
+++ b/datadog/event.go
@@ -1,0 +1,54 @@
+package datadog
+
+import (
+	"fmt"
+
+	"github.com/segmentio/stats"
+)
+
+// EventPriority is an enumeration providing the available datadog event
+// priority levels.
+type EventPriority string
+
+const (
+	EventPriorityNormal EventPriority = "normal"
+	EventPriorityLow    EventPriority = "low"
+)
+
+// EventAlertType is an enumeration providing the available datadog event
+// allert types.
+type EventAlertType string
+
+const (
+	EventAlertTypeError   EventAlertType = "error"
+	EventAlertTypeWarning EventAlertType = "warning"
+	EventAlertTypeInfo    EventAlertType = "info"
+	EventAlertTypeSuccess EventAlertType = "success"
+)
+
+// Event is a representation of a datadog event
+type Event struct {
+	Title          string
+	Text           string
+	Ts             int64
+	Priority       EventPriority
+	Host           string
+	Tags           []stats.Tag
+	AlertType      EventAlertType
+	AggregationKey string
+	SourceTypeName string
+	EventType      string
+}
+
+// String satisfies the fmt.Stringer interface.
+func (e Event) String() string {
+	return fmt.Sprint(e)
+}
+
+// Format satisfies the fmt.Formatter interface.
+func (e Event) Format(f fmt.State, _ rune) {
+	buf := bufferPool.Get().(*buffer)
+	buf.b = appendEvent(buf.b[:0], e)
+	f.Write(buf.b)
+	bufferPool.Put(buf)
+}

--- a/datadog/event_test.go
+++ b/datadog/event_test.go
@@ -1,0 +1,109 @@
+package datadog
+
+import (
+	"github.com/segmentio/stats"
+)
+
+var testEvents = []struct {
+	s string
+	e Event
+}{
+	{
+		s: "_e{10,9}:test title|test text\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,24}:test title|test\\line1\\nline2\\nline3\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test\\line1\nline2\nline3",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,24}:test|title|test\\line1\\nline2\\nline3\n",
+		e: Event{
+			Title:     "test|title",
+			Text:      "test\\line1\nline2\nline3",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|d:21\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Ts:        int64(21),
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|p:low\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Priority:  EventPriorityLow,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|h:localhost\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Host:      "localhost",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|t:warning\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeWarning,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|k:some aggregation key\n",
+		e: Event{
+			Title:          "test title",
+			Text:           "test text",
+			AggregationKey: "some aggregation key",
+			Priority:       EventPriorityNormal,
+			AlertType:      EventAlertTypeInfo,
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|s:this is the source\n",
+		e: Event{
+			Title:          "test title",
+			Text:           "test text",
+			Priority:       EventPriorityNormal,
+			AlertType:      EventAlertTypeInfo,
+			SourceTypeName: "this is the source",
+		},
+	},
+	{
+		s: "_e{10,9}:test title|test text|#tag1,tag2:test\n",
+		e: Event{
+			Title:     "test title",
+			Text:      "test text",
+			Priority:  EventPriorityNormal,
+			AlertType: EventAlertTypeInfo,
+			Tags: []stats.Tag{
+				stats.T("tag1", ""),
+				stats.T("tag2", "test"),
+			},
+		},
+	},
+}

--- a/datadog/parse.go
+++ b/datadog/parse.go
@@ -8,6 +8,107 @@ import (
 	"github.com/segmentio/stats"
 )
 
+// Adapted from https://github.com/DataDog/datadog-agent/blob/6789e98a1e41e98700fa1783df62238bb23cb454/pkg/dogstatsd/parser.go#L141
+func parseEvent(s string) (e Event, err error) {
+	var next = strings.TrimSpace(s)
+	var header string
+	var rawTitleLen string
+	var rawTextLen string
+	var titleLen int64
+	var textLen int64
+
+	header, next = nextToken(next, ':')
+	if len(header) < 7 {
+		err = fmt.Errorf("datadog: %#v has a malformed event header", s)
+		return
+	}
+
+	header = header[3 : len(header)-1] // Strip off '_e{' and '}'
+
+	rawTitleLen, rawTextLen = split(header, ',')
+
+	titleLen, err = strconv.ParseInt(rawTitleLen, 10, 64)
+	if err != nil {
+		err = fmt.Errorf("datadog: %#v has a malformed title length", s)
+		return
+	}
+
+	textLen, err = strconv.ParseInt(rawTextLen, 10, 64)
+	if err != nil {
+		err = fmt.Errorf("datadog: %#v has a malformed text length", s)
+		return
+	}
+
+	rawTitle := next[:titleLen]
+	rawText := next[titleLen+1 : titleLen+1+textLen]
+	next = next[titleLen+1+textLen:]
+
+	if len(rawTitle) == 0 {
+		err = fmt.Errorf("datadog: %#v has a malformed title", s)
+		return
+	}
+
+	if len(rawText) == 0 {
+		err = fmt.Errorf("datadog: %#v has malformed text", s)
+		return
+	}
+
+	e = Event{
+		Priority:  EventPriorityNormal,
+		AlertType: EventAlertTypeInfo,
+		Title:     rawTitle,
+		Text:      strings.Replace(rawText, "\\n", "\n", -1),
+	}
+
+	var tags string
+
+	// metadata
+	if len(next) > 1 {
+		rawMetadataFields := strings.Split(next[1:], "|")
+		for i := range rawMetadataFields {
+			switch rawMetadataFields[i][0] {
+			case 'd':
+				var ts int64
+				ts, err = strconv.ParseInt(rawMetadataFields[i][2:], 10, 64)
+				if err != nil {
+					err = fmt.Errorf("datadog: %#v has a malformed timestamp", s)
+					return
+				}
+				e.Ts = ts
+			case 'p':
+				e.Priority = EventPriority(rawMetadataFields[i][2:])
+			case 'h':
+				e.Host = rawMetadataFields[i][2:]
+			case 't':
+				e.AlertType = EventAlertType(rawMetadataFields[i][2:])
+			case 'k':
+				e.AggregationKey = rawMetadataFields[i][2:]
+			case 's':
+				e.SourceTypeName = rawMetadataFields[i][2:]
+			case '#':
+				tags = rawMetadataFields[i][1:]
+			default:
+				err = fmt.Errorf("datadog: %#v has unexpected metadata field", s)
+				return
+			}
+		}
+	}
+
+	if len(tags) != 0 {
+		e.Tags = make([]stats.Tag, 0, count(tags, ',')+1)
+
+		for len(tags) != 0 {
+			var tag string
+
+			if tag, tags = nextToken(tags, ','); len(tag) != 0 {
+				name, value := split(tag, ':')
+				e.Tags = append(e.Tags, stats.T(name, value))
+			}
+		}
+	}
+
+	return
+}
 func parseMetric(s string) (m Metric, err error) {
 	var next = strings.TrimSpace(s)
 	var name string

--- a/datadog/parse_test.go
+++ b/datadog/parse_test.go
@@ -48,3 +48,25 @@ func BenchmarkParseMetric(b *testing.B) {
 		})
 	}
 }
+
+func TestParseEventSuccess(t *testing.T) {
+	for _, test := range testEvents {
+		t.Run(test.s, func(t *testing.T) {
+			if e, err := parseEvent(test.s); err != nil {
+				t.Error(err)
+			} else if !reflect.DeepEqual(e, test.e) {
+				t.Errorf("%#v:\n- %#v\n- %#v", test.s, test.e, e)
+			}
+		})
+	}
+}
+
+func BenchmarkParseEvent(b *testing.B) {
+	for _, test := range testEvents {
+		b.Run(test.e.Title, func(b *testing.B) {
+			for i := 0; i != b.N; i++ {
+				parseEvent(test.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support in the dogstats server to accept and parse datadog events.

My use case is using the `segment/dogstatsd` container locally to echo my dogstats calls for debugging.  This pr allows that server to also print out any events messages that it receives.  

This PR also lays the groundwork for events parsing and serializing if we decide we want to support events natively, but doesn't expose them in the top level stats API.