### PR TITLE
Adding veneur integration for stats

### DIFF
--- a/veneur/client.go
+++ b/veneur/client.go
@@ -1,0 +1,122 @@
+package veneur
+
+import (
+	"time"
+
+	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/datadog"
+)
+
+const (
+	// DefaultAddress is the default address to which the veneur client tries
+	// to connect to.
+	DefaultAddress = "localhost:8125"
+
+	// DefaultBufferSize is the default size for batches of metrics sent to
+	// datadog.
+	DefaultBufferSize = 1024
+
+	// MaxBufferSize is a hard-limit on the max size of the datagram buffer.
+	MaxBufferSize = 65507
+
+	TagVeneurGlobalOnly = "veneurglobalonly"
+	TagVeneurLocalOnly  = "veneurlocalonly"
+	TagVeneurSinkOnly   = "veneursinkonly"
+)
+
+// DefaultFilter is the default tag to filter before sending to
+// datadog. Using the request path as a tag can overwhelm datadog's
+// servers if there are too many unique routes due to unique IDs being a
+// part of the path. Only change the default filter if there is a static
+// number of routes.
+var (
+	DefaultFilters = []string{"http_req_path"}
+)
+
+// The ClientConfig type is used to configure datadog clients.
+type ClientConfig struct {
+	// Address of the datadog database to send metrics to.
+	Address string
+
+	// Maximum size of batch of events sent to datadog.
+	BufferSize int
+
+	// List of tags to filter. If left nil is set to DefaultFilters.
+	Filters []string
+
+	// Veneur Specific Configuration
+
+	// If set true, all metrics will be sent with veneurglobalonly tag
+	GlobalOnly bool
+
+	// If set true, all metrics will be sent with veneurlocalonly tag
+	// Cannot be set in conjunction with GlobalOnly
+	LocalOnly bool
+
+	// Adds veneursinkonly:<sink> tag to all metrics. Valid sinks can be
+	// found here: https://github.com/stripe/veneur#routing-metrics
+	SinksOnly []string
+}
+
+// Client represents an datadog client that implements the stats.Handler
+// interface.
+type Client struct {
+	ddClient *datadog.Client
+	tags     []stats.Tag
+}
+
+// NewClient creates and returns a new datadog client publishing metrics to the
+// server running at addr.
+func NewClient(addr string) *Client {
+	return NewClientWith(ClientConfig{
+		Address: addr,
+	})
+}
+
+// NewClientWith creates and returns a new datadog client configured with the
+// given config.
+func NewClientWith(config ClientConfig) *Client {
+
+	// Construct Veneur-specific Tags we will append to measures
+	tags := []stats.Tag{}
+	if config.GlobalOnly {
+		tags = append(tags, stats.Tag{Name: TagVeneurGlobalOnly})
+	} else if config.LocalOnly {
+		tags = append(tags, stats.Tag{Name: TagVeneurLocalOnly})
+	}
+	for _, t := range config.SinksOnly {
+		tags = append(tags, stats.Tag{Name: TagVeneurSinkOnly, Value: t})
+	}
+
+	return &Client{
+		ddClient: datadog.NewClientWith(datadog.ClientConfig{
+			Address:    config.Address,
+			BufferSize: config.BufferSize,
+			Filters:    config.Filters,
+		}),
+		tags: tags,
+	}
+}
+
+// HandleMetric satisfies the stats.Handler interface.
+func (c *Client) HandleMeasures(time time.Time, measures ...stats.Measure) {
+	for _, m := range measures {
+		m.Tags = append(m.Tags, c.tags...)
+	}
+	c.ddClient.HandleMeasures(time, measures...)
+}
+
+// Flush satisfies the stats.Flusher interface.
+func (c *Client) Flush() {
+	c.ddClient.Flush()
+}
+
+// Write satisfies the io.Writer interface.
+func (c *Client) Write(b []byte) (int, error) {
+	return c.ddClient.Write(b)
+}
+
+// Close flushes and closes the client, satisfies the io.Closer interface.
+func (c *Client) Close() error {
+	return c.ddClient.Close()
+}

--- a/veneur/client.go
+++ b/veneur/client.go
@@ -17,7 +17,15 @@ const (
 	KafkaSink    = "kafka"
 )
 
-// The ClientConfig type is used to configure datadog clients.
+var (
+	TagSignalfxOnly = stats.Tag{Name: SinkOnly, Value: SignalfxSink}
+	TagDatadogOnly  = stats.Tag{Name: SinkOnly, Value: DatadogSink}
+	TagKafkaOnly    = stats.Tag{Name: SinkOnly, Value: KafkaSink}
+)
+
+// The ClientConfig type is used to configure veneur clients.
+// It inherits the datadog config since the veneur client reuses
+// the logic in the datadog client to emit metrics
 type ClientConfig struct {
 	datadog.ClientConfig
 
@@ -34,20 +42,25 @@ type ClientConfig struct {
 	SinksOnly []string
 }
 
-// Client represents an datadog client that implements the stats.Handler
+// Client represents an veneur client that implements the stats.Handler
 // interface.
 type Client struct {
 	*datadog.Client
 	tags []stats.Tag
 }
 
-// NewClient creates and returns a new datadog client publishing metrics to the
+// NewClient creates and returns a new veneur client publishing metrics to the
 // server running at addr.
 func NewClient(addr string) *Client {
 	return NewClientWith(ClientConfig{ClientConfig: datadog.ClientConfig{Address: addr}})
 }
 
-// NewClientWith creates and returns a new datadog client configured with the
+// NewClientGlobal creates a client that sends all metrics to the Global Veneur Aggregator
+func NewClientGlobal(addr string) *Client {
+	return NewClientWith(ClientConfig{ClientConfig: datadog.ClientConfig{Address: addr}, GlobalOnly: true})
+}
+
+// NewClientWith creates and returns a new veneur client configured with the
 // given config.
 func NewClientWith(config ClientConfig) *Client {
 

--- a/veneur/client.go
+++ b/veneur/client.go
@@ -11,6 +11,10 @@ const (
 	GlobalOnly = "veneurglobalonly"
 	LocalOnly  = "veneurlocalonly"
 	SinkOnly   = "veneursinkonly"
+
+	SignalfxSink = "signalfx"
+	DatadogSink  = "datadog"
+	KafkaSink    = "kafka"
 )
 
 // The ClientConfig type is used to configure datadog clients.

--- a/veneur/client.go
+++ b/veneur/client.go
@@ -8,44 +8,16 @@ import (
 )
 
 const (
-	// DefaultAddress is the default address to which the veneur client tries
-	// to connect to.
-	DefaultAddress = "localhost:8125"
-
-	// DefaultBufferSize is the default size for batches of metrics sent to
-	// datadog.
-	DefaultBufferSize = 1024
-
-	// MaxBufferSize is a hard-limit on the max size of the datagram buffer.
-	MaxBufferSize = 65507
-
 	TagVeneurGlobalOnly = "veneurglobalonly"
 	TagVeneurLocalOnly  = "veneurlocalonly"
 	TagVeneurSinkOnly   = "veneursinkonly"
 )
 
-// DefaultFilter is the default tag to filter before sending to
-// datadog. Using the request path as a tag can overwhelm datadog's
-// servers if there are too many unique routes due to unique IDs being a
-// part of the path. Only change the default filter if there is a static
-// number of routes.
-var (
-	DefaultFilters = []string{"http_req_path"}
-)
-
 // The ClientConfig type is used to configure datadog clients.
 type ClientConfig struct {
-	// Address of the datadog database to send metrics to.
-	Address string
-
-	// Maximum size of batch of events sent to datadog.
-	BufferSize int
-
-	// List of tags to filter. If left nil is set to DefaultFilters.
-	Filters []string
+	datadog.ClientConfig
 
 	// Veneur Specific Configuration
-
 	// If set true, all metrics will be sent with veneurglobalonly tag
 	GlobalOnly bool
 
@@ -61,16 +33,14 @@ type ClientConfig struct {
 // Client represents an datadog client that implements the stats.Handler
 // interface.
 type Client struct {
-	ddClient *datadog.Client
-	tags     []stats.Tag
+	*datadog.Client
+	tags []stats.Tag
 }
 
 // NewClient creates and returns a new datadog client publishing metrics to the
 // server running at addr.
 func NewClient(addr string) *Client {
-	return NewClientWith(ClientConfig{
-		Address: addr,
-	})
+	return NewClientWith(ClientConfig{ClientConfig: datadog.ClientConfig{Address: addr}})
 }
 
 // NewClientWith creates and returns a new datadog client configured with the
@@ -89,7 +59,7 @@ func NewClientWith(config ClientConfig) *Client {
 	}
 
 	return &Client{
-		ddClient: datadog.NewClientWith(datadog.ClientConfig{
+		Client: datadog.NewClientWith(datadog.ClientConfig{
 			Address:    config.Address,
 			BufferSize: config.BufferSize,
 			Filters:    config.Filters,
@@ -103,20 +73,5 @@ func (c *Client) HandleMeasures(time time.Time, measures ...stats.Measure) {
 	for _, m := range measures {
 		m.Tags = append(m.Tags, c.tags...)
 	}
-	c.ddClient.HandleMeasures(time, measures...)
-}
-
-// Flush satisfies the stats.Flusher interface.
-func (c *Client) Flush() {
-	c.ddClient.Flush()
-}
-
-// Write satisfies the io.Writer interface.
-func (c *Client) Write(b []byte) (int, error) {
-	return c.ddClient.Write(b)
-}
-
-// Close flushes and closes the client, satisfies the io.Closer interface.
-func (c *Client) Close() error {
-	return c.ddClient.Close()
+	c.Client.HandleMeasures(time, measures...)
 }

--- a/veneur/client_test.go
+++ b/veneur/client_test.go
@@ -1,0 +1,32 @@
+package veneur
+
+import (
+	"testing"
+	"time"
+
+	"github.com/segmentio/stats"
+)
+
+func TestClient(t *testing.T) {
+	client := NewClientWith(ClientConfig{
+		GlobalOnly: true,
+		SinksOnly:  []string{SignalfxSink},
+	})
+
+	for i := 0; i != 1000; i++ {
+		client.HandleMeasures(time.Time{}, stats.Measure{
+			Name: "request",
+			Fields: []stats.Field{
+				{Name: "count", Value: stats.ValueOf(5)},
+				{Name: "rtt", Value: stats.ValueOf(100 * time.Millisecond)},
+			},
+			Tags: []stats.Tag{
+				TagSignalfxOnly,
+			},
+		})
+	}
+
+	if err := client.Close(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Note: this is a first pass. If we agree with this direction, I can go ahead and add tests.

Veneur [supports the DogStatsd protocol](https://github.com/stripe/veneur#what-is-veneur), so I chose to inherit the statsd functionality from the existing Datadog integration.

Veneur supports [Magic Tags](https://github.com/stripe/veneur#magic-tag) that help with routing metrics. We need this feature to route high cardinality metrics only to the Signalfx backend.

We need to add the `VeneurGlobalOnly` Tag for all SignalFX metrics or else our DPM will be higher than what our contract permits. If we set `VeneurGlobalOnly` on the Engine's Global tags, this will affect our current Datadog metrics (which is not something we want to do).

So, by adding veneur tags only to a veneur backend as I've done here, we can:
1. Register a Veneur Handler with VeneurGlobalOnly and enable only the SignalfxSink
2. Register a Datadog Handler (to keep metrics as they were)
3. Write metrics to both such that we both get high cardinality metrics in Signalfx and don't change the behavior of our current Datadog setup.

This is more complex than I would like it to be, but due to some limitations with routing metrics and feature imparity between Signalfx and Datadog, this is what I've come up with.

I'm open to other suggestions. Let me know what you think! 