### PR TITLE
feat(tags): add M helper to convert map to tag list

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -22,6 +22,15 @@ func (t Tag) String() string {
 	return t.Name + "=" + t.Value
 }
 
+// M allows for creating a tag list from a map.
+func M(m map[string]string) []Tag {
+	tags := make([]Tag, 0, len(m))
+	for k, v := range m {
+		tags = append(tags, T(k, v))
+	}
+	return tags
+}
+
 // TagsAreSorted returns true if the given list of tags is sorted by tag name,
 // false otherwise.
 func TagsAreSorted(tags []Tag) bool {

--- a/tag_test.go
+++ b/tag_test.go
@@ -109,6 +109,41 @@ func TestTagsAreSorted(t *testing.T) {
 	}
 }
 
+func TestM(t *testing.T) {
+	tests := []struct {
+		input    map[string]string
+		expected []Tag
+	}{
+		{
+			input: map[string]string{
+				"A": "",
+			},
+			expected: []Tag{
+				T("A", ""),
+			},
+		},
+		{
+			input: map[string]string{
+				"a": "A",
+				"b": "B",
+				"c": "C",
+			},
+			expected: []Tag{
+				T("a", "A"),
+				T("b", "B"),
+				T("c", "C"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := M(test.input)
+		if !reflect.DeepEqual(SortTags(test.expected), SortTags(actual)) {
+			t.Errorf("expected %v, got %v", test.expected, actual)
+		}
+	}
+}
+
 func BenchmarkTagsOrder(b *testing.B) {
 	b.Run("TagsAreSorted", func(b *testing.B) {
 		benchmarkTagsOrder(b, TagsAreSorted)


### PR DESCRIPTION
This PR proposes a new helper to give another option for building tag lists with a map:

```go
tags := stats.M(map[string]string{
	"a": "A",
    "b": "B",
})
```