### PR TITLE
Fix a few misspells

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ func main() {
 
 The [github.com/segmentio/stats/httpstats](https://godoc.org/github.com/segmentio/stats/httpstats)
 package exposes a decorator of `http.Handler` that automatically adds metric
-colleciton to a HTTP handler, reporting things like request processing time,
+collection to a HTTP handler, reporting things like request processing time,
 error counters, header and body sizes...
 
 Here's an example of how to use the decorator:
@@ -265,7 +265,7 @@ The [github.com/segmentio/stats/httpstats](https://godoc.org/github.com/segmenti
 package exposes a decorator of `http.RoundTripper` which collects and reports
 metrics for client requests the same way it's done on the server side.
 
-Here's an exmaple of how to use the decorator:
+Here's an example of how to use the decorator:
 ```go
 package main
 
@@ -327,7 +327,7 @@ package exposes:
   [`redis.ServeRedis`](https://godoc.org/github.com/segmentio/redis-go#HandlerFunc.ServeRedis)
   which collects metrics for server requests.
 
-Here's an exmaple of how to use the decorator on the client side:
+Here's an example of how to use the decorator on the client side:
 ```go
 package main
 

--- a/field.go
+++ b/field.go
@@ -22,7 +22,7 @@ func (f Field) Type() FieldType {
 
 func (f *Field) setType(t FieldType) {
 	// We pack the field type into the value's padding space to make copies and
-	// assignments of fields more time efficent.
+	// assignments of fields more time efficient.
 	// Here are the results of a microbenchmark showing the performance of
 	// a simple assignment for a Field type of 40 bytes (with a Type field) vs
 	// an assignment of a Tag type (32 bytes).
@@ -47,7 +47,7 @@ const (
 	// Counter represents incrementing counter metrics.
 	Counter FieldType = iota
 
-	// Guage represents metrics that snapshot a value that may increase and
+	// Gauge represents metrics that snapshot a value that may increase and
 	// decrease.
 	Gauge
 

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -127,7 +127,7 @@ func NewProcMetricsWith(eng *stats.Engine, pid int) *ProcMetrics {
 	return p
 }
 
-// Collect satsifies the Collector interface.
+// Collect satisfies the Collector interface.
 func (p *ProcMetrics) Collect() {
 	if m, err := CollectProcInfo(p.pid); err == nil {
 		now := time.Now()


### PR DESCRIPTION
Fixes typos found while running `misspell`:
```
field.go:25:36: "efficent" is a misspelling of "efficient"
field.go:50:4: "Guage" is a misspelling of "Gauge"
README.md:232:0: "colleciton" is a misspelling of "collection"
README.md:268:10: "exmaple" is a misspelling of "example"
README.md:330:10: "exmaple" is a misspelling of "example"
procstats/proc.go:130:11: "satsifies" is a misspelling of "satisfies"
```