### PR TITLE
feat(engine): add ClockAt for creating a clock with a specific start time

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -101,13 +101,18 @@ func (eng *Engine) Observe(name string, value interface{}, tags ...Tag) {
 
 // Clock returns a new clock identified by name and tags.
 func (eng *Engine) Clock(name string, tags ...Tag) *Clock {
+	return eng.ClockAt(name, time.Now(), tags...)
+}
+
+// ClockAt returns a new clock identified by name and tags with a specified
+// start time.
+func (eng *Engine) ClockAt(name string, start time.Time, tags ...Tag) *Clock {
 	cpy := make([]Tag, len(tags), len(tags)+1) // clock always appends a stamp.
 	copy(cpy, tags)
-	now := time.Now()
 	return &Clock{
 		name:  name,
-		first: now,
-		last:  now,
+		first: start,
+		last:  start,
 		tags:  cpy,
 		eng:   eng,
 	}


### PR DESCRIPTION
This adds a helper (`Engine.ClockAt`) for creating a clock with a specified start time, rather than assuming `time.Now()`. The existing `Engine.Clock` method still works as originally designed.