### PR TITLE
normalize CPU usage metrics

### DIFF
--- a/procstats/delaystats.go
+++ b/procstats/delaystats.go
@@ -48,6 +48,8 @@ type DelayInfo struct {
 	FreePagesDelay time.Duration
 }
 
-func CollectDelayInfo(pid int) (DelayInfo, error) {
-	return collectDelayInfo(pid)
+func CollectDelayInfo(pid int) (info DelayInfo, err error) {
+	defer func() { err = convertPanicToError(recover()) }()
+	info = collectDelayInfo(pid)
+	return
 }

--- a/procstats/delaystats_darwin.go
+++ b/procstats/delaystats_darwin.go
@@ -1,6 +1,6 @@
 package procstats
 
-func collectDelayInfo(pid int) (info DelayInfo, err error) {
+func collectDelayInfo(pid int) (info DelayInfo) {
 	// TODO
 	return
 }

--- a/procstats/delaystats_linux.go
+++ b/procstats/delaystats_linux.go
@@ -7,7 +7,7 @@ import (
 	"github.com/segmentio/taskstats"
 )
 
-func collectDelayInfo(pid int) (info DelayInfo, err error) {
+func collectDelayInfo(pid int) DelayInfo {
 	client, err := taskstats.New()
 	if err == syscall.ENOENT {
 		err = errors.New("Failed to communicate with taskstats Netlink family.  Ensure this program is not running in a network namespace.")
@@ -20,10 +20,10 @@ func collectDelayInfo(pid int) (info DelayInfo, err error) {
 	}
 	check(err)
 
-	info.BlockIODelay = stats.BlockIODelay
-	info.CPUDelay = stats.CPUDelay
-	info.FreePagesDelay = stats.FreePagesDelay
-	info.SwapInDelay = stats.SwapInDelay
-
-	return info, nil
+	return DelayInfo{
+		BlockIODelay:   stats.BlockIODelay,
+		CPUDelay:       stats.CPUDelay,
+		FreePagesDelay: stats.FreePagesDelay,
+		SwapInDelay:    stats.SwapInDelay,
+	}
 }

--- a/procstats/delaystats_test.go
+++ b/procstats/delaystats_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,12 @@ import (
 )
 
 func TestProcMetrics(t *testing.T) {
+	u, err := user.Current()
+	if err != nil || u.Uid != "0" {
+		t.Log("test needs to be run as root")
+		t.Skip()
+	}
+
 	rand.Seed(time.Now().UnixNano())
 
 	h := &statstest.Handler{}

--- a/procstats/delaystats_windows.go
+++ b/procstats/delaystats_windows.go
@@ -1,6 +1,6 @@
 package procstats
 
-func collectDelayInfo(pid int) (m proc, err error) {
+func collectDelayInfo(pid int) (info DelayInfo) {
 	// TODO
 	return
 }

--- a/procstats/linux/cgroup_test.go
+++ b/procstats/linux/cgroup_test.go
@@ -45,62 +45,61 @@ func TestParseProcCGroup(t *testing.T) {
 	}
 }
 
-func TestProcCGroupGetByID(t *testing.T) {
+func TestProcCGroupLookup(t *testing.T) {
 	tests := []struct {
-		proc    ProcCGroup
-		id      int
-		cgroups []CGroup
+		proc   ProcCGroup
+		name   string
+		cgroup CGroup
 	}{
 		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			id:      0,
-			cgroups: nil,
+			proc: ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
+			name: "",
 		},
 		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			id:      1,
-			cgroups: []CGroup{{1, "A", "/"}},
+			proc:   ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
+			name:   "A",
+			cgroup: CGroup{1, "A", "/"},
 		},
 		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			id:      2,
-			cgroups: []CGroup{{2, "B", "/"}, {2, "C", "/"}},
+			proc:   ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
+			name:   "B",
+			cgroup: CGroup{2, "B", "/"},
 		},
 	}
 
 	for _, test := range tests {
-		if cgroups := test.proc.GetByID(test.id); !reflect.DeepEqual(cgroups, test.cgroups) {
-			t.Errorf("bad cgroups from id %v: %v != %v", test.id, test.cgroups, cgroups)
+		if cgroup, _ := test.proc.Lookup(test.name); !reflect.DeepEqual(cgroup, test.cgroup) {
+			t.Errorf("bad cgroups from name %v: %+v != %+v", test.name, test.cgroup, cgroup)
 		}
 	}
 }
 
-func TestProcCGroupGetByName(t *testing.T) {
-	tests := []struct {
-		proc    ProcCGroup
-		name    string
-		cgroups []CGroup
-	}{
-		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			name:    "",
-			cgroups: nil,
-		},
-		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			name:    "A",
-			cgroups: []CGroup{{1, "A", "/"}},
-		},
-		{
-			proc:    ProcCGroup{{1, "A", "/"}, {2, "B", "/"}, {2, "C", "/"}},
-			name:    "B",
-			cgroups: []CGroup{{2, "B", "/"}},
-		},
+func TestReadCPUPeriod(t *testing.T) {
+	period, err := ReadCPUPeriod("")
+	if err != nil {
+		t.Fatal(err)
 	}
+	if period == 0 {
+		t.Fatal("invalid CPU period:", period)
+	}
+}
 
-	for _, test := range tests {
-		if cgroups := test.proc.GetByName(test.name); !reflect.DeepEqual(cgroups, test.cgroups) {
-			t.Errorf("bad cgroups from name %v: %v != %v", test.name, test.cgroups, cgroups)
-		}
+func TestReadCPUQuota(t *testing.T) {
+	quota, err := ReadCPUQuota("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quota == 0 {
+		t.Fatal("invalid CPU quota:", quota)
+	}
+}
+
+func TestReadCPUShares(t *testing.T) {
+	shares, err := ReadCPUShares("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shares == 0 {
+		t.Fatal("invalid CPU shares:", shares)
 	}
 }

--- a/procstats/linux/files.go
+++ b/procstats/linux/files.go
@@ -2,13 +2,13 @@ package linux
 
 import "os"
 
-func GetOpenFileCount(pid int) (n uint64, err error) {
+func ReadOpenFileCount(pid int) (n uint64, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
-	n = getOpenFileCount(pid)
+	n = readOpenFileCount(pid)
 	return
 }
 
-func getOpenFileCount(pid int) uint64 {
+func readOpenFileCount(pid int) uint64 {
 	f, err := os.Open(procPath(pid, "fd"))
 	check(err)
 	defer f.Close()

--- a/procstats/linux/files_linux_test.go
+++ b/procstats/linux/files_linux_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestGetOpenFileCount(t *testing.T) {
-	if count, err := GetOpenFileCount(os.Getpid()); err != nil {
-		t.Error("GetOpenFileCount:", err)
+func TestReadOpenFileCount(t *testing.T) {
+	if count, err := ReadOpenFileCount(os.Getpid()); err != nil {
+		t.Error("ReadOpenFileCount:", err)
 	} else if count == 0 {
-		t.Error("GetOpenFileCount: cannot return zero")
+		t.Error("ReadOpenFileCount: cannot return zero")
 	}
 }

--- a/procstats/linux/io.go
+++ b/procstats/linux/io.go
@@ -3,11 +3,15 @@ package linux
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 )
 
 func readFile(path string) string {
-	b, e := ioutil.ReadFile(path)
-	check(e)
+	b, err := ioutil.ReadFile(path)
+	check(err)
 	return string(b)
 }
 
@@ -15,6 +19,24 @@ func readProcFile(who interface{}, what string) string {
 	return readFile(procPath(who, what))
 }
 
+func readMicrosecondFile(path string) time.Duration {
+	return time.Duration(readIntFile(path)) * time.Microsecond
+}
+
+func readIntFile(path string) int64 {
+	return parseInt(strings.TrimSpace(readFile(path)))
+}
+
+func parseInt(s string) int64 {
+	i, err := strconv.ParseInt(s, 10, 64)
+	check(err)
+	return i
+}
+
 func procPath(who interface{}, what string) string {
-	return fmt.Sprintf("/proc/%v/%s", who, what)
+	return filepath.Join("/proc", fmt.Sprint(who), what)
+}
+
+func cgroupPath(dir, cgroup, file string) string {
+	return filepath.Join("/sys/fs/cgroup", dir, cgroup, file)
 }

--- a/procstats/linux/limits.go
+++ b/procstats/linux/limits.go
@@ -32,7 +32,7 @@ type ProcLimits struct {
 	RealtimeTimeout  Limits
 }
 
-func GetProcLimits(pid int) (proc ProcLimits, err error) {
+func ReadProcLimits(pid int) (proc ProcLimits, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
 	proc = parseProcLimits(readProcFile(pid, "limits"))
 	return

--- a/procstats/linux/limits_linux_test.go
+++ b/procstats/linux/limits_linux_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestGetProcLimits(t *testing.T) {
-	if limits, err := GetProcLimits(os.Getpid()); err != nil {
-		t.Error("GetProcLimits:", err)
+func TestReadProcLimits(t *testing.T) {
+	if limits, err := ReadProcLimits(os.Getpid()); err != nil {
+		t.Error("ReadProcLimits:", err)
 	} else if limits.CPUTime.Hard == 0 {
-		t.Error("GetProcLimits: hard cpu time limit cannot be zero")
+		t.Error("ReadProcLimits: hard cpu time limit cannot be zero")
 	}
 }

--- a/procstats/linux/memory.go
+++ b/procstats/linux/memory.go
@@ -4,4 +4,4 @@ const (
 	unlimitedMemoryLimit = 9223372036854771712
 )
 
-func GetMemoryLimit(pid int) (limit uint64, err error) { return getMemoryLimit(pid) }
+func ReadMemoryLimit(pid int) (limit uint64, err error) { return readMemoryLimit(pid) }

--- a/procstats/linux/memory_darwin.go
+++ b/procstats/linux/memory_darwin.go
@@ -1,6 +1,6 @@
 package linux
 
-func getMemoryLimit(pid int) (limit uint64, err error) {
+func readMemoryLimit(pid int) (limit uint64, err error) {
 	limit = unlimitedMemoryLimit
 	return
 }

--- a/procstats/linux/memory_linux_test.go
+++ b/procstats/linux/memory_linux_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestGetMemoryLimit(t *testing.T) {
-	if limit, err := GetMemoryLimit(os.Getpid()); err != nil {
+func TestReadMemoryLimit(t *testing.T) {
+	if limit, err := ReadMemoryLimit(os.Getpid()); err != nil {
 		t.Error(err)
 
 	} else if limit == 0 {

--- a/procstats/linux/parse.go
+++ b/procstats/linux/parse.go
@@ -6,20 +6,26 @@ import (
 	"unicode"
 )
 
-func forEachLine(text string, call func(string)) {
+func forEachToken(text, split string, call func(string)) {
 	for len(text) != 0 {
 		var line string
 
-		if i := strings.IndexByte(text, '\n'); i >= 0 {
-			line, text = text[:i], text[i+1:]
+		if i := strings.Index(text, split); i >= 0 {
+			line, text = text[:i], text[i+len(split):]
 		} else {
 			line, text = text, ""
 		}
 
-		if line = strings.TrimSpace(line); len(line) != 0 {
+		call(line)
+	}
+}
+
+func forEachLine(text string, call func(string)) {
+	forEachToken(text, "\n", func(line string) {
+		if line = strings.TrimSpace(line); line != "" {
 			call(line)
 		}
-	}
+	})
 }
 
 func forEachLineExceptFirst(text string, call func(string)) {

--- a/procstats/linux/sched.go
+++ b/procstats/linux/sched.go
@@ -12,7 +12,7 @@ type ProcSched struct {
 	SEAvgUtilAvg          uint64 // se.avg.util_avg
 }
 
-func GetProcSched(pid int) (proc ProcSched, err error) {
+func ReadProcSched(pid int) (proc ProcSched, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
 	proc = parseProcSched(readProcFile(pid, "sched"))
 	return

--- a/procstats/linux/sched_linux_test.go
+++ b/procstats/linux/sched_linux_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestGetProcSched(t *testing.T) {
-	if _, err := GetProcSched(os.Getpid()); err != nil {
-		t.Error("GetProcSched:", err)
+func TestReadProcSched(t *testing.T) {
+	if _, err := ReadProcSched(os.Getpid()); err != nil {
+		t.Error("ReadProcSched:", err)
 	}
 }

--- a/procstats/linux/stat.go
+++ b/procstats/linux/stat.go
@@ -84,7 +84,7 @@ type ProcStat struct {
 	ExitCode            int32     // (52) exit_code
 }
 
-func GetProcStat(pid int) (proc ProcStat, err error) {
+func ReadProcStat(pid int) (proc ProcStat, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
 	return ParseProcStat(readProcFile(pid, "stat"))
 }

--- a/procstats/linux/stat_linux_test.go
+++ b/procstats/linux/stat_linux_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestGetProcStat(t *testing.T) {
-	if stat, err := GetProcStat(os.Getpid()); err != nil {
-		t.Error("GetProcStat:", err)
+func TestReadProcStat(t *testing.T) {
+	if stat, err := ReadProcStat(os.Getpid()); err != nil {
+		t.Error("ReadProcStat:", err)
 	} else if int(stat.Pid) != os.Getpid() {
-		t.Error("GetPorcStat: invalid pid returned:", stat.Pid)
+		t.Error("ReadPorcStat: invalid pid returned:", stat.Pid)
 	}
 }

--- a/procstats/linux/statm.go
+++ b/procstats/linux/statm.go
@@ -12,7 +12,7 @@ type ProcStatm struct {
 	Dt       uint64 // (7) dt
 }
 
-func GetProcStatm(pid int) (proc ProcStatm, err error) {
+func ReadProcStatm(pid int) (proc ProcStatm, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
 	return ParseProcStatm(readProcFile(pid, "statm"))
 }

--- a/procstats/linux/statm_linux_test.go
+++ b/procstats/linux/statm_linux_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestGetProcStatm(t *testing.T) {
-	if statm, err := GetProcStatm(os.Getpid()); err != nil {
-		t.Error("GetProcStatm:", err)
+func TestReadProcStatm(t *testing.T) {
+	if statm, err := ReadProcStatm(os.Getpid()); err != nil {
+		t.Error("ReadProcStatm:", err)
 	} else if statm.Size == 0 {
-		t.Error("GetPorcStatm: size cannot be zero")
+		t.Error("ReadPorcStatm: size cannot be zero")
 	}
 }

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -133,16 +133,25 @@ func (p *ProcMetrics) Collect() {
 		now := time.Now()
 
 		if !p.lastTime.IsZero() {
-			interval := now.Sub(p.lastTime)
+			ratio := 1.0
+			switch {
+			case m.CPU.Period > 0 && m.CPU.Quota > 0:
+				ratio = float64(m.CPU.Quota) / float64(m.CPU.Period)
+			case m.CPU.Shares > 0:
+				ratio = float64(m.CPU.Shares) / 1024
+			}
+
+			interval := ratio * float64(now.Sub(p.lastTime))
 
 			p.cpu.user.time = m.CPU.User - p.last.CPU.User
-			p.cpu.user.percent = 100 * float64(p.cpu.user.time) / float64(interval)
+			p.cpu.user.percent = 100 * float64(p.cpu.user.time) / interval
 
 			p.cpu.system.time = m.CPU.Sys - p.last.CPU.Sys
-			p.cpu.system.percent = 100 * float64(p.cpu.system.time) / float64(interval)
+			p.cpu.system.percent = 100 * float64(p.cpu.system.time) / interval
 
 			p.cpu.total.time = (m.CPU.User + m.CPU.Sys) - (p.last.CPU.User + p.last.CPU.Sys)
-			p.cpu.total.percent = 100 * float64(p.cpu.total.time) / float64(interval)
+			p.cpu.total.percent = 100 * float64(p.cpu.total.time) / interval
+
 		}
 
 		p.memory.available = m.Memory.Available
@@ -182,6 +191,13 @@ func CollectProcInfo(pid int) (ProcInfo, error) {
 type CPUInfo struct {
 	User time.Duration // user cpu time used by the process
 	Sys  time.Duration // system cpu time used by the process
+
+	// Linux-specific details about the CPU configuration of the process.
+	//
+	// The values are all zero if they are not known.
+	Period time.Duration // scheduler period
+	Quota  time.Duration // time quota in the scheduler period
+	Shares int64         // 1024 scaled value representing the CPU shares
 }
 
 type MemoryInfo struct {

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -2,6 +2,7 @@ package procstats
 
 import (
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/segmentio/stats"
@@ -139,6 +140,8 @@ func (p *ProcMetrics) Collect() {
 				ratio = float64(m.CPU.Quota) / float64(m.CPU.Period)
 			case m.CPU.Shares > 0:
 				ratio = float64(m.CPU.Shares) / 1024
+			default:
+				ratio = 1 / float64(runtime.NumCPU())
 			}
 
 			interval := ratio * float64(now.Sub(p.lastTime))

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -195,6 +195,10 @@ type CPUInfo struct {
 	// Linux-specific details about the CPU configuration of the process.
 	//
 	// The values are all zero if they are not known.
+	//
+	// For more details on what those values represent see:
+	//	https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+	//	https://kernel.googlesource.com/pub/scm/linux/kernel/git/glommer/memcg/+/cpu_stat/Documentation/cgroups/cpu.txt
 	Period time.Duration // scheduler period
 	Quota  time.Duration // time quota in the scheduler period
 	Shares int64         // 1024 scaled value representing the CPU shares


### PR DESCRIPTION
This PR adds the CPU period, quota, and shares to the info reported by the procstats package, and uses it to normalize the CPU usage metrics.

I've also spent a bit of time cleaning up parts of the code, this package was almost two years old and deserved a bit of love.

Please take a look and let me know if anything should be changed.