### PR TITLE
Add support for per request tags

### DIFF
--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -7,6 +7,8 @@ import (
 	"github.com/segmentio/stats"
 )
 
+const contextKeyReqTags = "segmentio_httpstats_req_tags"
+
 // NewTransport wraps t to produce metrics on the default engine for every request
 // sent and every response received.
 func NewTransport(t http.RoundTripper) http.RoundTripper {
@@ -27,12 +29,26 @@ type transport struct {
 	eng       *stats.Engine
 }
 
+// RequestWithContext returns a shallow copy of req with its context changed with this provided tags
+// so the they can be used later during the RoundTrip in the metrics recording.
+// The provided ctx must be non-nil.
+func RequestWithContext(req *http.Request, tags ...Tags) *http.Request {
+	ctx := req.Context()
+	ctx = ctx.WithValue(ctx, contextKeyReqTags, tags)
+	return req.WithContext(ctx)
+}
+
 func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	start := time.Now()
 	rtrip := t.transport
+	eng := t.eng
 
 	if rtrip == nil {
 		rtrip = http.DefaultTransport
+	}
+
+	if tags, ok := req.Context().Value(contextKeyReqTags).([]stats.Tag); ok {
+		eng = eng.WithTags(tags...)
 	}
 
 	if req.Body == nil {
@@ -42,7 +58,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	m := &metrics{}
 
 	req.Body = &requestBody{
-		eng:     t.eng,
+		eng:     eng,
 		req:     req,
 		metrics: m,
 		body:    req.Body,
@@ -54,10 +70,10 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 	if err != nil {
 		m.observeError(time.Now().Sub(start))
-		t.eng.ReportAt(start, m)
+		eng.ReportAt(start, m)
 	} else {
 		res.Body = &responseBody{
-			eng:     t.eng,
+			eng:     eng,
 			res:     res,
 			metrics: m,
 			body:    res.Body,


### PR DESCRIPTION
As reported on https://github.com/segmentio/stats/issues/93 and documented in Go api it seems to be a bad practice using a new client/transport instance on every request.

https://golang.org/pkg/net/http/#Client
> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines.

and

> Clients and Transports are safe for concurrent use by multiple goroutines and for efficiency should only be created once and re-used.

So, a solution that came to my mind is passing the tags by Context and creating the stats engine with thos provided tags during the round trip.

I would like to get a feedback if segmentio team is interested on this changes before adding the proper documentation and tests for this change.