### PR TITLE
use interface instead of *stats.Engine in httpstats

### DIFF
--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -62,7 +62,7 @@ func (n *nullBody) Read(b []byte) (int, error) { return 0, io.EOF }
 
 type requestBody struct {
 	body    io.ReadCloser
-	eng     *stats.Engine
+	eng     Reporter
 	req     *http.Request
 	metrics *metrics
 	bytes   int
@@ -92,7 +92,7 @@ func (r *requestBody) complete() {
 }
 
 type responseBody struct {
-	eng     *stats.Engine
+	eng     Reporter
 	res     *http.Response
 	metrics *metrics
 	body    io.ReadCloser

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -7,6 +7,11 @@ import (
 	"github.com/segmentio/stats"
 )
 
+// Reporter is the interface for reporting stats at a given time
+type Reporter interface {
+	ReportAt(time time.Time, metrics interface{}, tags ...stats.Tag)
+}
+
 // NewTransport wraps t to produce metrics on the default engine for every request
 // sent and every response received.
 func NewTransport(t http.RoundTripper) http.RoundTripper {
@@ -15,7 +20,7 @@ func NewTransport(t http.RoundTripper) http.RoundTripper {
 
 // NewTransportWith wraps t to produce metrics on eng for every request sent and
 // every response received.
-func NewTransportWith(eng *stats.Engine, t http.RoundTripper) http.RoundTripper {
+func NewTransportWith(eng Reporter, t http.RoundTripper) http.RoundTripper {
 	return &transport{
 		transport: t,
 		eng:       eng,
@@ -24,7 +29,7 @@ func NewTransportWith(eng *stats.Engine, t http.RoundTripper) http.RoundTripper 
 
 type transport struct {
 	transport http.RoundTripper
-	eng       *stats.Engine
+	eng       Reporter
 }
 
 func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error) {


### PR DESCRIPTION
the only method used is `ReportAt`. This way the consumer (httpstats) is asking for a specific behavior (`ReportAt`). 

Benefits: 
- the behavior required is more clear and readable
- mocks can be used to test that the reporting is actually called where expected
