### PR TITLE
fix netstat metric names

### DIFF
--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -42,7 +42,7 @@ func NewConnWith(eng *stats.Engine, c net.Conn) net.Conn {
 	nc.r.metrics.protocol = proto
 	nc.w.metrics.protocol = proto
 
-	eng.Incr("conn.open:count", stats.T("protocol", proto))
+	eng.Incr("conn.open.count", stats.T("protocol", proto))
 	return nc
 }
 
@@ -77,7 +77,7 @@ func (c *conn) BaseConn() net.Conn {
 func (c *conn) Close() (err error) {
 	err = c.Conn.Close()
 	c.once.Do(func() {
-		c.eng.Incr("conn.close:count", stats.T("protocol", c.w.metrics.protocol))
+		c.eng.Incr("conn.close.count", stats.T("protocol", c.w.metrics.protocol))
 		if err != nil {
 			c.error("close", err)
 		}
@@ -145,7 +145,7 @@ func (c *conn) error(op string, err error) {
 	default:
 		// only report serious errors, others should be handled gracefully
 		if !isTemporary(err) {
-			c.eng.Incr("conn.error:count",
+			c.eng.Incr("conn.error.count",
 				stats.T("operation", op),
 				stats.T("protocol", c.w.metrics.protocol),
 			)

--- a/netstats/listener.go
+++ b/netstats/listener.go
@@ -49,7 +49,7 @@ func (l *listener) Addr() net.Addr {
 
 func (l *listener) error(op string, err error) {
 	if !isTemporary(err) {
-		l.eng.Incr("conn.error:count",
+		l.eng.Incr("conn.error.count",
 			stats.T("operation", op),
 			stats.T("protocol", l.Addr().Network()),
 		)


### PR DESCRIPTION
Follow up of #90 which fixed a backward incompatible change, but kind of broke the (rarely used) API...

We could have done a better job managing major versions with this package, not sure if this should represent a major version bump or not. Let me know what you think!