### PR TITLE
Add user agent tag for httpstats package

### DIFF
--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -25,6 +25,16 @@ func NewHandlerWith(eng *stats.Engine, h http.Handler) http.Handler {
 	}
 }
 
+// NewHandlerWithConfig wraps h to produce metrics on eng for every request received
+// and every response sent and uses the provided configuration for customization
+func NewHandlerWithConfig(conf *HandlerConfig, eng *stats.Engine, h http.Handler) http.Handler {
+	return &handler{
+		handler: h,
+		eng:     eng,
+		conf:    conf,
+	}
+}
+
 type HandlerConfig struct {
 	DisableUserAgent bool
 }
@@ -37,10 +47,6 @@ type handler struct {
 	handler http.Handler
 	eng     *stats.Engine
 	conf    *HandlerConfig
-}
-
-func (h *handler) Configure(c *HandlerConfig) {
-	h.conf = c
 }
 
 func (h *handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -171,6 +171,7 @@ type metrics struct {
 		contentType      string `tag:"http_req_content_type"`
 		host             string `tag:"http_req_host"`
 		method           string `tag:"http_req_method"`
+		userAgent        string `tag:"http_req_user_agent"`
 		path             string `tag:"http_req_path"`
 		protocol         string `tag:"http_req_protocol"`
 		transferEncoding string `tag:"http_req_transfer_encoding"`
@@ -195,6 +196,7 @@ func (m *metrics) observeRequest(req *http.Request, op string, bodyLen int) {
 	m.http.contentEncoding = contentEncoding
 	m.http.contentType = contentType
 	m.http.host = host
+	m.http.userAgent = req.UserAgent()
 	m.http.method = req.Method
 	m.http.protocol = req.Proto
 	m.http.transferEncoding = transferEncoding


### PR DESCRIPTION
Curious whether you've thought or would be willing to add user agent as a tag for http stats. It's unbounded in the number of permutations so it could result in high cardinality. At the same time, for internal services, where user agents are generally constrained, it would be very helpful. Could also update the PR to add configuration such that user agent is by default disabled, but give the user the ability to enable it for specific services