### PR TITLE
context: add support for carrying tags on context, use in httpstats.Handler

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,12 +3,16 @@ package stats
 import "context"
 
 func ContextWithTags(ctx context.Context, tags ...Tag) context.Context {
-	if x := getTagSlice(ctx); x != nil {
-		*x = append(*x, tags...)
-		return ctx
-	}
 	// initialize the context reference and return a new context
 	return context.WithValue(ctx, contextKeyReqTags, &tags)
+}
+
+func ContextAddTags(ctx context.Context, tags ...Tag) bool {
+	if x := getTagSlice(ctx); x != nil {
+		*x = append(*x, tags...)
+		return true
+	}
+	return false
 }
 
 func ContextTags(ctx context.Context) []Tag {

--- a/context.go
+++ b/context.go
@@ -2,11 +2,21 @@ package stats
 
 import "context"
 
+// ContextWithTags returns a new child context with the given tags.  If the
+// parent context already has tags set on it, they are _not_ propegated into
+// the context children.
 func ContextWithTags(ctx context.Context, tags ...Tag) context.Context {
 	// initialize the context reference and return a new context
 	return context.WithValue(ctx, contextKeyReqTags, &tags)
 }
 
+// ContextAddTags adds the given tags to the given context, if the tags have
+// been set on any of the ancestor contexts.  ContextAddTags returns true
+// if tags were successfully appended to the context, and false otherwise.
+//
+// The proper way to set tags on a context if you don't know whether or not
+// tags already exist on the context is to first call ContextAddTags, and if
+// that returns false, then call ContextWithTags instead.
 func ContextAddTags(ctx context.Context, tags ...Tag) bool {
 	if x := getTagSlice(ctx); x != nil {
 		*x = append(*x, tags...)
@@ -15,6 +25,8 @@ func ContextAddTags(ctx context.Context, tags ...Tag) bool {
 	return false
 }
 
+// ContextTags returns a copy of the tags on the context if they exist and nil
+// if they don't exist
 func ContextTags(ctx context.Context) []Tag {
 	if x := getTagSlice(ctx); x != nil {
 		ret := make([]Tag, len(*x))

--- a/context.go
+++ b/context.go
@@ -1,0 +1,43 @@
+package stats
+
+import "context"
+
+func ContextWithTags(ctx context.Context, tags ...Tag) context.Context {
+	if x := getTagSlice(ctx); x != nil {
+		*x = append(*x, tags...)
+		return ctx
+	}
+	// initialize the context reference and return a new context
+	return context.WithValue(ctx, contextKeyReqTags, &tags)
+}
+
+func ContextTags(ctx context.Context) []Tag {
+	if x := getTagSlice(ctx); x != nil {
+		ret := make([]Tag, len(*x))
+		copy(ret, *x)
+		return ret
+	}
+	return nil
+}
+
+func getTagSlice(ctx context.Context) *[]Tag {
+	if tags, ok := ctx.Value(contextKeyReqTags).(*[]Tag); ok {
+		return tags
+	}
+	return nil
+}
+
+// tagsKey is a value for use with context.WithValue. It's used as
+// a pointer so it fits in an interface{} without allocation. This technique
+// for defining context keys was copied from Go 1.7's new use of context in net/http.
+type tagsKey struct{}
+
+// String is Stringer implementation
+func (k *tagsKey) String() string {
+	return "stats_tags_context_key"
+}
+
+// contextKeyReqTags is contextKey for tags
+var (
+	contextKeyReqTags = &tagsKey{}
+)

--- a/context.go
+++ b/context.go
@@ -33,11 +33,11 @@ func getTagSlice(ctx context.Context) *[]Tag {
 type tagsKey struct{}
 
 // String is Stringer implementation
-func (k *tagsKey) String() string {
+func (k tagsKey) String() string {
 	return "stats_tags_context_key"
 }
 
 // contextKeyReqTags is contextKey for tags
 var (
-	contextKeyReqTags = &tagsKey{}
+	contextKeyReqTags = tagsKey{}
 )

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,33 @@
+package stats
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextTags(t *testing.T) {
+	x := context.Background()
+
+	y := ContextWithTags(x)
+	assert.Equal(t, 0, len(ContextTags(y)), "Initialize context tags context value")
+	ContextAddTags(y, T("asdf", "qwer"))
+	assert.Equal(t, 1, len(ContextTags(y)), "Adding tags should result new tags")
+	assert.Equal(t, 0, len(ContextTags(x)), "Original context should have no tags (because no context with key)")
+
+	// create a child context which creates a child context
+	z := context.WithValue(y, "not", "important")
+	assert.Equal(t, 1, len(ContextTags(z)), "We should still be able to see original tags")
+
+	// Add tags to the child context's reference to the original tag slice
+	ContextAddTags(z, T("zxcv", "uiop"))
+	assert.Equal(t, 2, len(ContextTags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 2, len(ContextTags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(ContextTags(x)), "Updating tags should not appear on original context")
+
+	ContextAddTags(z, T("a", "k"), T("b", "k"), T("c", "k"), T("d", "k"), T("e", "k"), T("f", "k"))
+	assert.Equal(t, 8, len(ContextTags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 8, len(ContextTags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(ContextTags(x)), "Updating tags should not appear on original context")
+}

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -7,11 +7,17 @@ import (
 	"github.com/segmentio/stats"
 )
 
-// RequestWithTags returns a shallow copy of req with its context changed with this provided tags
-// so the they can be used later during the RoundTrip in the metrics recording.
-// The provided ctx must be non-nil.
+// RequestWithTags returns a shallow copy of req with its context changed with
+// this provided tags so the they can be used later.  The provided ctx must be
+// non-nil.  If the context value has already been initialized, it appends the
+// tags to the existing reference and returns the existing Request.
 func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
 	ctx := req.Context()
+	// first try adding tags to the request
+	if AddTagsToRequest(req, tags...) {
+		return req
+	}
+	// otherwise initialize the context reference and return a shallow copy
 	ctx = context.WithValue(ctx, contextKeyReqTags, &tags)
 	return req.WithContext(ctx)
 }

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -14,6 +14,6 @@ func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
 	return req.WithContext(stats.ContextWithTags(req.Context(), tags...))
 }
 
-func Tags(req *http.Request) []stats.Tag {
+func RequestTags(req *http.Request) []stats.Tag {
 	return stats.ContextTags(req.Context())
 }

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -1,7 +1,6 @@
 package httpstats
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/segmentio/stats"
@@ -12,57 +11,9 @@ import (
 // non-nil.  If the context value has already been initialized, it appends the
 // tags to the existing reference and returns the existing Request.
 func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
-	ctx := req.Context()
-	// first try adding tags to the request
-	if AddTagsToRequest(req, tags...) {
-		return req
-	}
-	// otherwise initialize the context reference and return a shallow copy
-	ctx = context.WithValue(ctx, contextKeyReqTags, &tags)
-	return req.WithContext(ctx)
+	return req.WithContext(stats.ContextWithTags(req.Context(), tags...))
 }
 
-// AddTagsToRequest adds the given tags to the request if the reqeuest context
-// has already been initialized with tags. It returns a bool which is true if
-// the context value exists and they were added, false otherwise.
-func AddTagsToRequest(req *http.Request, tags ...stats.Tag) bool {
-	cur := getReqTagsSlice(req)
-	if cur == nil {
-		return false
-	}
-	*cur = append(*cur, tags...)
-	return true
-}
-
-// Tags returns a copy of the tags on the request, if they exist.  Otherwise it
-// returns nil.
 func Tags(req *http.Request) []stats.Tag {
-	if x := getReqTagsSlice(req); x != nil {
-		ret := make([]stats.Tag, len(*x))
-		copy(ret, *x)
-		return ret
-	}
-	return nil
+	return stats.ContextTags(req.Context())
 }
-
-func getReqTagsSlice(req *http.Request) *[]stats.Tag {
-	if tags, ok := req.Context().Value(contextKeyReqTags).(*[]stats.Tag); ok {
-		return tags
-	}
-	return nil
-}
-
-// tagsKey is a value for use with context.WithValue. It's used as
-// a pointer so it fits in an interface{} without allocation. This technique
-// for defining context keys was copied from Go 1.7's new use of context in net/http.
-type tagsKey struct{}
-
-// String is Stringer implementation
-func (k *tagsKey) String() string {
-	return "stats_tags_context_key"
-}
-
-// contextKeyReqTags is contextKey for tags
-var (
-	contextKeyReqTags = &tagsKey{}
-)

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -6,14 +6,19 @@ import (
 	"github.com/segmentio/stats"
 )
 
-// RequestWithTags returns a shallow copy of req with its context changed with
-// this provided tags so the they can be used later.  The provided ctx must be
-// non-nil.  If the context value has already been initialized, it appends the
-// tags to the existing reference and returns the existing Request.
+// RequestWithTags returns a shallow copy of req with its context updated to
+// include the given tags.  If the context already contains tags, then those
+// are appended to, otherwise a new context containing the tags is created and
+// attached to the new request
 func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
+	if stats.ContextAddTags(req.Context(), tags...) {
+		return req.WithContext(req.Context())
+	}
 	return req.WithContext(stats.ContextWithTags(req.Context(), tags...))
 }
 
+// RequestTags returns the tags associated with the request, if any.  It
+// returns nil otherwise.
 func RequestTags(req *http.Request) []stats.Tag {
 	return stats.ContextTags(req.Context())
 }

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -1,0 +1,62 @@
+package httpstats
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/segmentio/stats"
+)
+
+// RequestWithTags returns a shallow copy of req with its context changed with this provided tags
+// so the they can be used later during the RoundTrip in the metrics recording.
+// The provided ctx must be non-nil.
+func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, contextKeyReqTags, &tags)
+	return req.WithContext(ctx)
+}
+
+// AddTagsToRequest adds the given tags to the request if the reqeuest context
+// has already been initialized with tags. It returns a bool which is true if
+// the context value exists and they were added, false otherwise.
+func AddTagsToRequest(req *http.Request, tags ...stats.Tag) bool {
+	cur := getReqTagsSlice(req)
+	if cur == nil {
+		return false
+	}
+	*cur = append(*cur, tags...)
+	return true
+}
+
+// Tags returns a copy of the tags on the request, if they exist.  Otherwise it
+// returns nil.
+func Tags(req *http.Request) []stats.Tag {
+	if x := getReqTagsSlice(req); x != nil {
+		ret := make([]stats.Tag, len(*x))
+		copy(ret, *x)
+		return ret
+	}
+	return nil
+}
+
+func getReqTagsSlice(req *http.Request) *[]stats.Tag {
+	if tags, ok := req.Context().Value(contextKeyReqTags).(*[]stats.Tag); ok {
+		return tags
+	}
+	return nil
+}
+
+// tagsKey is a value for use with context.WithValue. It's used as
+// a pointer so it fits in an interface{} without allocation. This technique
+// for defining context keys was copied from Go 1.7's new use of context in net/http.
+type tagsKey struct{}
+
+// String is Stringer implementation
+func (k *tagsKey) String() string {
+	return "stats_tags_context_key"
+}
+
+// contextKeyReqTags is contextKey for tags
+var (
+	contextKeyReqTags = &tagsKey{}
+)

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -1,0 +1,37 @@
+package httpstats
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/segmentio/stats"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextTags(t *testing.T) {
+	// dummy request
+	x := httptest.NewRequest(http.MethodGet, "http://example.com/blah", nil)
+
+	y := RequestWithTags(x)
+	assert.Equal(t, 0, len(Tags(y)), "Initialize request tags context value")
+	AddTagsToRequest(y, stats.T("asdf", "qwer"))
+	assert.Equal(t, 1, len(Tags(y)), "Adding tags should result new tags")
+	assert.Equal(t, 0, len(Tags(x)), "Original request should have no tags (because no context with key)")
+
+	// create a child request which creates a child context
+	z := y.WithContext(context.WithValue(y.Context(), "not", "important"))
+	assert.Equal(t, 1, len(Tags(z)), "We should still be able to see original tags")
+
+	// Add tags to the child context's reference to the original tag slice
+	AddTagsToRequest(z, stats.T("zxcv", "uiop"))
+	assert.Equal(t, 2, len(Tags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 2, len(Tags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")
+
+	AddTagsToRequest(z, stats.T("a", "k"), stats.T("b", "k"), stats.T("c", "k"), stats.T("d", "k"), stats.T("e", "k"), stats.T("f", "k"))
+	assert.Equal(t, 8, len(Tags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 8, len(Tags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")
+}

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -16,7 +16,7 @@ func TestContextTags(t *testing.T) {
 
 	y := RequestWithTags(x)
 	assert.Equal(t, 0, len(Tags(y)), "Initialize request tags context value")
-	AddTagsToRequest(y, stats.T("asdf", "qwer"))
+	RequestWithTags(y, stats.T("asdf", "qwer"))
 	assert.Equal(t, 1, len(Tags(y)), "Adding tags should result new tags")
 	assert.Equal(t, 0, len(Tags(x)), "Original request should have no tags (because no context with key)")
 
@@ -25,12 +25,12 @@ func TestContextTags(t *testing.T) {
 	assert.Equal(t, 1, len(Tags(z)), "We should still be able to see original tags")
 
 	// Add tags to the child context's reference to the original tag slice
-	AddTagsToRequest(z, stats.T("zxcv", "uiop"))
+	RequestWithTags(z, stats.T("zxcv", "uiop"))
 	assert.Equal(t, 2, len(Tags(z)), "Updating tags should update local reference")
 	assert.Equal(t, 2, len(Tags(y)), "Updating tags should update parent reference")
 	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")
 
-	AddTagsToRequest(z, stats.T("a", "k"), stats.T("b", "k"), stats.T("c", "k"), stats.T("d", "k"), stats.T("e", "k"), stats.T("f", "k"))
+	RequestWithTags(z, stats.T("a", "k"), stats.T("b", "k"), stats.T("c", "k"), stats.T("d", "k"), stats.T("e", "k"), stats.T("f", "k"))
 	assert.Equal(t, 8, len(Tags(z)), "Updating tags should update local reference")
 	assert.Equal(t, 8, len(Tags(y)), "Updating tags should update parent reference")
 	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -15,23 +15,23 @@ func TestContextTags(t *testing.T) {
 	x := httptest.NewRequest(http.MethodGet, "http://example.com/blah", nil)
 
 	y := RequestWithTags(x)
-	assert.Equal(t, 0, len(Tags(y)), "Initialize request tags context value")
+	assert.Equal(t, 0, len(RequestTags(y)), "Initialize request tags context value")
 	RequestWithTags(y, stats.T("asdf", "qwer"))
-	assert.Equal(t, 1, len(Tags(y)), "Adding tags should result new tags")
-	assert.Equal(t, 0, len(Tags(x)), "Original request should have no tags (because no context with key)")
+	assert.Equal(t, 1, len(RequestTags(y)), "Adding tags should result new tags")
+	assert.Equal(t, 0, len(RequestTags(x)), "Original request should have no tags (because no context with key)")
 
 	// create a child request which creates a child context
 	z := y.WithContext(context.WithValue(y.Context(), "not", "important"))
-	assert.Equal(t, 1, len(Tags(z)), "We should still be able to see original tags")
+	assert.Equal(t, 1, len(RequestTags(z)), "We should still be able to see original tags")
 
 	// Add tags to the child context's reference to the original tag slice
 	RequestWithTags(z, stats.T("zxcv", "uiop"))
-	assert.Equal(t, 2, len(Tags(z)), "Updating tags should update local reference")
-	assert.Equal(t, 2, len(Tags(y)), "Updating tags should update parent reference")
-	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")
+	assert.Equal(t, 2, len(RequestTags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 2, len(RequestTags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(RequestTags(x)), "Updating tags should not appear on original request")
 
 	RequestWithTags(z, stats.T("a", "k"), stats.T("b", "k"), stats.T("c", "k"), stats.T("d", "k"), stats.T("e", "k"), stats.T("f", "k"))
-	assert.Equal(t, 8, len(Tags(z)), "Updating tags should update local reference")
-	assert.Equal(t, 8, len(Tags(y)), "Updating tags should update parent reference")
-	assert.Equal(t, 0, len(Tags(x)), "Updating tags should not appear on original request")
+	assert.Equal(t, 8, len(RequestTags(z)), "Updating tags should update local reference")
+	assert.Equal(t, 8, len(RequestTags(y)), "Updating tags should update parent reference")
+	assert.Equal(t, 0, len(RequestTags(x)), "Updating tags should not appear on original request")
 }

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContextTags(t *testing.T) {
+// TestRequestContextTagPropegation verifies that the root ancestor tags are
+// updated in the event the context or request has children.  It's nearly
+// identical to the context_test in the stats package itself, but we want to
+// keep this to ensure that changes to the request context code doesn't drift
+// and cause bugs.
+func TestRequestContextTagPropegation(t *testing.T) {
 	// dummy request
 	x := httptest.NewRequest(http.MethodGet, "http://example.com/blah", nil)
 

--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -118,5 +118,5 @@ func (w *responseWriter) complete() {
 	}
 
 	w.metrics.observeResponse(res, "write", w.bytes, now.Sub(w.start))
-	w.eng.ReportAt(w.start, w.metrics, Tags(w.req)...)
+	w.eng.ReportAt(w.start, w.metrics, RequestTags(w.req)...)
 }

--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -35,7 +35,7 @@ func (h *handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	w := &responseWriter{
 		ResponseWriter: res,
 		eng:            h.eng,
-		req:            req,
+		req:            RequestWithTags(req),
 		metrics:        m,
 		start:          time.Now(),
 	}
@@ -118,5 +118,5 @@ func (w *responseWriter) complete() {
 	}
 
 	w.metrics.observeResponse(res, "write", w.bytes, now.Sub(w.start))
-	w.eng.ReportAt(w.start, w.metrics)
+	w.eng.ReportAt(w.start, w.metrics, Tags(w.req)...)
 }

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -37,7 +37,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		rtrip = http.DefaultTransport
 	}
 
-	if tags := Tags(req); len(tags) > 0 {
+	if tags := RequestTags(req); len(tags) > 0 {
 		eng = eng.WithTags(tags...)
 	}
 

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -4,23 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"context"
 	"github.com/segmentio/stats"
-)
-
-// tagsKey is a value for use with context.WithValue. It's used as
-// a pointer so it fits in an interface{} without allocation. This technique
-// for defining context keys was copied from Go 1.7's new use of context in net/http.
-type tagsKey struct{}
-
-// String is Stringer implementation
-func (k *tagsKey) String() string {
-	return "stats_tags_context_key"
-}
-
-// contextKeyReqTags is contextKey for tags
-var (
-	contextKeyReqTags = &tagsKey{}
 )
 
 // NewTransport wraps t to produce metrics on the default engine for every request
@@ -43,15 +27,6 @@ type transport struct {
 	eng       *stats.Engine
 }
 
-// RequestWithTags returns a shallow copy of req with its context changed with this provided tags
-// so the they can be used later during the RoundTrip in the metrics recording.
-// The provided ctx must be non-nil.
-func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
-	ctx := req.Context()
-	ctx = context.WithValue(ctx, contextKeyReqTags, tags)
-	return req.WithContext(ctx)
-}
-
 // RoundTrip implements http.RoundTripper
 func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	start := time.Now()
@@ -62,7 +37,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		rtrip = http.DefaultTransport
 	}
 
-	if tags, ok := req.Context().Value(contextKeyReqTags).([]stats.Tag); ok {
+	if tags := Tags(req); len(tags) > 0 {
 		eng = eng.WithTags(tags...)
 	}
 


### PR DESCRIPTION
Recently had a need to add this, and I can see it being useful generally.

It _might_ supersede #109, but I could see them both being useful and not exclusive of one another.

In fact, @f2prateek suggested exactly this, haha: https://github.com/segmentio/stats/pull/109#issuecomment-530580543