### PR TITLE
httpstats: fix handler

### DIFF
--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -10,6 +10,8 @@ import (
 // include the given tags.  If the context already contains tags, then those
 // are appended to, otherwise a new context containing the tags is created and
 // attached to the new request
+// ⚠️ : Using this may blow up the cardinality of your httpstats metrics. Use
+// with care for tags with low cardinalities.
 func RequestWithTags(req *http.Request, tags ...stats.Tag) *http.Request {
 	if stats.ContextAddTags(req.Context(), tags...) {
 		return req.WithContext(req.Context())

--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -32,10 +32,11 @@ type handler struct {
 func (h *handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	m := &metrics{}
 
+	req = RequestWithTags(req)
 	w := &responseWriter{
 		ResponseWriter: res,
 		eng:            h.eng,
-		req:            RequestWithTags(req),
+		req:            req,
 		metrics:        m,
 		start:          time.Now(),
 	}


### PR DESCRIPTION
This PR fixes the httpstats reporting.

Before this fix, if you tried tagging the httpstats with a new tag, it wouldn't go through because the tags weren't initialized.  That's because before this PR, we are passing the original request down to the wrapped handler and only initializing the tags on the responseWriter's reference to `req`.

Want to figure out how to test it before we merge.