### PR TITLE
Add IsValidValue method to stats package.

### DIFF
--- a/buckets.go
+++ b/buckets.go
@@ -16,7 +16,7 @@ func (b HistogramBuckets) Set(key string, buckets ...interface{}) {
 	v := make([]Value, len(buckets))
 
 	for i, b := range buckets {
-		v[i] = ValueOf(b)
+		v[i] = MustValueOf(ValueOf(b))
 	}
 
 	b[makeKey(key)] = v

--- a/field.go
+++ b/field.go
@@ -10,7 +10,7 @@ type Field struct {
 
 // MakeField constructs and returns a new Field from name, value, and ftype.
 func MakeField(name string, value interface{}, ftype FieldType) Field {
-	f := Field{Name: name, Value: ValueOf(value)}
+	f := Field{Name: name, Value: MustValueOf(ValueOf(value))}
 	f.setType(ftype)
 	return f
 }

--- a/value.go
+++ b/value.go
@@ -12,35 +12,11 @@ type Value struct {
 	bits uint64
 }
 
-// IsValidValue returns true if the supplied value's concrete type is acceptable.
-// This is useful in situations where the client program does not know the underlying
-// type ahead of time.  A common scenario is deserializaing metrics payloads from
-// other APIs and feeding them into stats, as the deserialized metrics could be of
-// type map[string]interface{}.
-//
-// NB: these type assertions should be kept in sync with ValueOf
-func IsValidValue(v interface{}) bool {
-	switch v.(type) {
-	case nil:
-	case bool:
-	case int:
-	case int8:
-	case int16:
-	case int32:
-	case int64:
-	case uint:
-	case uint8:
-	case uint16:
-	case uint32:
-	case uint64:
-	case uintptr:
-	case float32:
-	case float64:
-	case time.Duration:
-	default:
-		return false
+func MustValueOf(v Value) Value {
+	if v.Type() == Invalid {
+		panic("stats.MustValueOf received a value of unsupported type")
 	}
-	return true
+	return v
 }
 
 func ValueOf(v interface{}) Value {
@@ -78,7 +54,7 @@ func ValueOf(v interface{}) Value {
 	case time.Duration:
 		return durationValue(x)
 	default:
-		panic("stats.ValueOf received a value of unsupported type")
+		return Value{typ: Invalid}
 	}
 }
 
@@ -213,6 +189,7 @@ const (
 	Uint
 	Float
 	Duration
+	Invalid
 )
 
 func (t Type) String() string {

--- a/value.go
+++ b/value.go
@@ -21,6 +21,8 @@ func MustValueOf(v Value) Value {
 
 func ValueOf(v interface{}) Value {
 	switch x := v.(type) {
+	case Value:
+		return x
 	case nil:
 		return Value{}
 	case bool:

--- a/value.go
+++ b/value.go
@@ -12,6 +12,37 @@ type Value struct {
 	bits uint64
 }
 
+// IsValidValue returns true if the supplied value's concrete type is acceptable.
+// This is useful in situations where the client program does not know the underlying
+// type ahead of time.  A common scenario is deserializaing metrics payloads from
+// other APIs and feeding them into stats, as the deserialized metrics could be of
+// type map[string]interface{}.
+//
+// NB: these type assertions should be kept in sync with ValueOf
+func IsValidValue(v interface{}) bool {
+	switch v.(type) {
+	case nil:
+	case bool:
+	case int:
+	case int8:
+	case int16:
+	case int32:
+	case int64:
+	case uint:
+	case uint8:
+	case uint16:
+	case uint32:
+	case uint64:
+	case uintptr:
+	case float32:
+	case float64:
+	case time.Duration:
+	default:
+		return false
+	}
+	return true
+}
+
 func ValueOf(v interface{}) Value {
 	switch x := v.(type) {
 	case nil:

--- a/value_test.go
+++ b/value_test.go
@@ -41,6 +41,14 @@ func TestMustValueOf(t *testing.T) {
 	}
 }
 
+func TestValueOfIdentity(t *testing.T) {
+	v1 := ValueOf(3.14)
+	v2 := ValueOf(v1)
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("Expected %+v to be equal to %+v", v2, v1)
+	}
+}
+
 func TestValueOf(t *testing.T) {
 	tests := []struct {
 		in  interface{}

--- a/value_test.go
+++ b/value_test.go
@@ -5,7 +5,41 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestMustValueOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    interface{}
+		out   interface{}
+		panic bool
+	}{
+		{
+			name: "should not panic",
+			in:   42,
+			out:  ValueOf(42),
+		},
+		{
+			name:  "should panic",
+			in:    struct{}{},
+			panic: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.panic {
+				require.PanicsWithValue(t, "stats.MustValueOf received a value of unsupported type", func() {
+					MustValueOf(ValueOf(test.in))
+				})
+			} else {
+				out := MustValueOf(ValueOf(test.in))
+				require.EqualValues(t, test.out, out)
+			}
+		})
+	}
+}
 
 func TestValueOf(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
For programs which import opaque metrics from 3rd party APIs and
then pass those into the stats package, this will help them avoid
panics that result from passing in invalid values (such as structs
or maps) that the 3rd party API might have returned.

