### PR TITLE
Add zone information in netstats via vpcinfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/segmentio/objconv v1.0.1
+	github.com/segmentio/vpcinfo v0.1.10
 	github.com/stretchr/testify v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszj
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
+github.com/segmentio/vpcinfo v0.1.10 h1:iCfT3tS4h2M7WLWmzFGKysZh0ql0B8XdiHYqiPN4ke4=
+github.com/segmentio/vpcinfo v0.1.10/go.mod h1:KEIWiWRE/KLh90mOzOY0QkFWT7ObUYLp978tICtquqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -47,7 +47,12 @@ func TestConn(t *testing.T) {
 				stats.MakeField("count", 1, stats.Counter),
 				stats.MakeField("bytes", 12, stats.Histogram),
 			},
-			Tags: []stats.Tag{stats.T("protocol", "tcp")},
+			Tags: []stats.Tag{
+				stats.T("in_zone", "false"),
+				stats.T("protocol", "tcp"),
+				stats.T("source_zone", "N/A"),
+				stats.T("target_zone", "N/A"),
+			},
 		},
 		{
 			Name: "netstats.test.conn.read",
@@ -55,7 +60,12 @@ func TestConn(t *testing.T) {
 				stats.MakeField("count", 1, stats.Counter),
 				stats.MakeField("bytes", 12, stats.Histogram),
 			},
-			Tags: []stats.Tag{stats.T("protocol", "tcp")},
+			Tags: []stats.Tag{
+				stats.T("in_zone", "false"),
+				stats.T("protocol", "tcp"),
+				stats.T("source_zone", "N/A"),
+				stats.T("target_zone", "N/A"),
+			},
 		},
 		{
 			Name: "netstats.test.conn.close",
@@ -134,7 +144,10 @@ func TestConnError(t *testing.T) {
 				stats.MakeField("bytes", 0, stats.Histogram),
 			},
 			Tags: []stats.Tag{
+				stats.T("in_zone", "false"),
 				stats.T("protocol", "tcp"),
+				stats.T("source_zone", "N/A"),
+				stats.T("target_zone", "N/A"),
 			},
 		},
 		{
@@ -154,7 +167,10 @@ func TestConnError(t *testing.T) {
 				stats.MakeField("bytes", 0, stats.Histogram),
 			},
 			Tags: []stats.Tag{
+				stats.T("in_zone", "false"),
 				stats.T("protocol", "tcp"),
+				stats.T("source_zone", "N/A"),
+				stats.T("target_zone", "N/A"),
 			},
 		},
 		{


### PR DESCRIPTION
We built the `vpcinfo` system to be able to get information about the network where the service is running via DNS. This is a nice way to propagate low level information without having to carry the configuration in the application.

This PR leverage `vpcinfo` in the `netstats` package to add zone information and identify if the traffic is happening cross AZ. This is mostly reusing the work done in Cv3.