### PR TITLE
Add Datadog UDS support

### DIFF
--- a/datadog/client.go
+++ b/datadog/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultAddress is the default address to which the datadog client tries
-	// to connect to. By default it connects to UDP
+	// to connect to.
 	DefaultAddress = "localhost:8125"
 
 	// DefaultBufferSize is the default size for batches of metrics sent to
@@ -38,7 +38,7 @@ var (
 // The ClientConfig type is used to configure datadog clients.
 type ClientConfig struct {
 	// Address of the datadog database to send metrics to.
-	// UDP: host:port
+	// UDP: host:port (default)
 	// UDS: unixgram://dir/file.ext
 	Address string
 
@@ -269,10 +269,12 @@ func (w *noopWriter) Write(data []byte) (int, error) {
 	return 0, nil
 }
 
+// Close is a noop close
 func (w *noopWriter) Close() error {
 	return nil
 }
 
+// CalcBufferSize returns the sizehint
 func (w *noopWriter) CalcBufferSize(sizehint int) (int, error) {
 	return sizehint, nil
 }

--- a/datadog/client.go
+++ b/datadog/client.go
@@ -261,7 +261,7 @@ func newWriter(addr string) (ddWriter, error) {
 	return newUDPWriter(addr)
 }
 
-// noopWriter is a writer that does not do anything
+// noopWriter is a writer that does nothing
 type noopWriter struct{}
 
 // Write writes nothing

--- a/datadog/client.go
+++ b/datadog/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultAddress is the default address to which the datadog client tries
-	// to connect to. By default is connects to UDP
+	// to connect to. By default it connects to UDP
 	DefaultAddress = "localhost:8125"
 
 	// DefaultBufferSize is the default size for batches of metrics sent to
@@ -101,7 +101,7 @@ func NewClientWith(config ClientConfig) *Client {
 
 	newBufSize, err := w.CalcBufferSize(config.BufferSize)
 	if err != nil {
-		log.Printf("stats/datadog: unable to calc buffer size from connn. Defaulting to a buffer of size %d - %v\n", DefaultBufferSize, err)
+		log.Printf("stats/datadog: unable to calc writer's buffer size. Defaulting to a buffer of size %d - %v\n", DefaultBufferSize, err)
 		newBufSize = DefaultBufferSize
 	}
 	c.bufferSize = newBufSize
@@ -109,7 +109,7 @@ func NewClientWith(config ClientConfig) *Client {
 
 	c.serializer.w = w
 	c.buffer.Serializer = &c.serializer
-	log.Printf("stats/datadog: sending metrics with a buffer of size %d B", c.serializer.bufferSize)
+	log.Printf("stats/datadog: sending metrics with a buffer of size %d B", newBufSize)
 	return c
 }
 
@@ -200,7 +200,7 @@ func bufSizeFromFD(f *os.File, sizehint int) (bufsize int, err error) {
 	// to accept larger datagrams, or fallback to the default socket buffer size
 	// if it failed.
 	if bufsize, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF); err != nil {
-		return 0, err
+		return
 	}
 
 	// The kernel applies a 2x factor on the socket buffer size, only half of it

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -106,7 +106,7 @@ func startUDSTestServerWithSocketFile(t *testing.T, socketPath string, handler H
 	}
 }
 
-// startUDSTestServer starts a Unix domain socket server with a random tmp file for the socket file
+// startUDSTestServer starts a Unix domain socket server with a random socket file
 func startUDSTestServer(t *testing.T, handler Handler) (socketPath string, closer io.Closer) {
 	dir, err := ioutil.TempDir("", "socket")
 	if err != nil {

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -106,7 +106,7 @@ func startUDSTestServerWithSocketFile(t *testing.T, socketPath string, handler H
 	}
 }
 
-// startUDSTestServer starts a Unix domain socket server with a random socket file
+// startUDSTestServer starts a UDS server with server with a random socket file internally generated
 func startUDSTestServer(t *testing.T, handler Handler) (socketPath string, closer io.Closer) {
 	dir, err := ioutil.TempDir("", "socket")
 	if err != nil {

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -106,8 +106,9 @@ func startUDSTestServerWithSocketFile(t *testing.T, socketPath string, handler H
 	}
 }
 
-// startUDSTestServer starts a UDS server with server with a random socket file internally generated
+// startUDSTestServer starts a UDS server with a random socket file internally generated
 func startUDSTestServer(t *testing.T, handler Handler) (socketPath string, closer io.Closer) {
+	// generate a random dir
 	dir, err := ioutil.TempDir("", "socket")
 	if err != nil {
 		t.Error(err)

--- a/datadog/udp.go
+++ b/datadog/udp.go
@@ -1,0 +1,42 @@
+package datadog
+
+import "net"
+
+// udsWriter is an internal class wrapping around management of UDS connection
+type udpWriter struct {
+	conn net.Conn
+}
+
+// newUDSWriter returns a pointer to a new udpWriter given a socket file path as addr.
+func newUDPWriter(addr string) (*udpWriter, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return nil, err
+	}
+	return &udpWriter{conn: conn}, nil
+
+}
+
+// Write data to the UDS connection with write timeout and minimal error handling:
+// create the connection if nil, and destroy it if the statsd server has disconnected
+func (w *udpWriter) Write(data []byte) (int, error) {
+	return w.conn.Write(data)
+}
+
+func (w *udpWriter) Close() error {
+	return w.conn.Close()
+}
+
+func (w *udpWriter) CalcBufferSize(sizehint int) (int, error) {
+	f, err := w.conn.(*net.UDPConn).File()
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	return bufSizeFromFD(f, sizehint)
+}

--- a/datadog/udp.go
+++ b/datadog/udp.go
@@ -2,12 +2,11 @@ package datadog
 
 import "net"
 
-// udsWriter is an internal class wrapping around management of UDS connection
 type udpWriter struct {
 	conn net.Conn
 }
 
-// newUDSWriter returns a pointer to a new udpWriter given a socket file path as addr.
+// newUDPWriter returns a pointer to a new newUDPWriter given a socket file path as addr.
 func newUDPWriter(addr string) (*udpWriter, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
@@ -21,8 +20,7 @@ func newUDPWriter(addr string) (*udpWriter, error) {
 
 }
 
-// Write data to the UDS connection with write timeout and minimal error handling:
-// create the connection if nil, and destroy it if the statsd server has disconnected
+// Write data to the UDP connection
 func (w *udpWriter) Write(data []byte) (int, error) {
 	return w.conn.Write(data)
 }

--- a/datadog/uds.go
+++ b/datadog/uds.go
@@ -1,0 +1,108 @@
+package datadog
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// UDSTimeout holds the default timeout for UDS socket writes, as they can get
+// blocking when the receiving buffer is full.
+// same value as in official datadog client: https://github.com/DataDog/datadog-go/blob/master/statsd/uds.go#L13
+const defaultUDSTimeout = 1 * time.Millisecond
+
+// udsWriter is an internal class wrapping around management of UDS connection
+// credits to Datadog team: https://github.com/DataDog/datadog-go/blob/master/statsd/uds.go
+type udsWriter struct {
+	// Address to send metrics to, needed to allow reconnection on error
+	addr net.Addr
+
+	// Established connection object, or nil if not connected yet
+	conn   net.Conn
+	connMu sync.RWMutex // so that we can replace the failing conn on error
+
+	// write timeout
+	writeTimeout time.Duration
+}
+
+// newUDSWriter returns a pointer to a new udsWriter given a socket file path as addr.
+func newUDSWriter(addr string) (*udsWriter, error) {
+	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
+	if err != nil {
+		return nil, err
+	}
+	// Defer connection to first Write
+	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: defaultUDSTimeout}
+	return writer, nil
+}
+
+// Write data to the UDS connection with write timeout and minimal error handling:
+// create the connection if nil, and destroy it if the statsd server has disconnected
+func (w *udsWriter) Write(data []byte) (int, error) {
+	conn, err := w.ensureConnection()
+	if err != nil {
+		return 0, err
+	}
+
+	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	n, e := conn.Write(data)
+	if err, isNetworkErr := e.(net.Error); err != nil && (!isNetworkErr || !err.Temporary()) {
+		// Statsd server disconnected, retry connecting at next packet
+		w.unsetConnection()
+		return 0, e
+	}
+	return n, e
+}
+
+func (w *udsWriter) Close() error {
+	if w.conn != nil {
+		return w.conn.Close()
+	}
+	return nil
+}
+
+func (w *udsWriter) CalcBufferSize(sizehint int) (int, error) {
+	conn, err := w.ensureConnection()
+	if err != nil {
+		return 0, err
+	}
+	f, err := conn.(*net.UnixConn).File()
+	if err != nil {
+		w.unsetConnection()
+		return 0, err
+	}
+	defer f.Close()
+
+	return bufSizeFromFD(f, sizehint)
+}
+
+func (w *udsWriter) ensureConnection() (net.Conn, error) {
+	// Check if we've already got a socket we can use
+	w.connMu.RLock()
+	currentConn := w.conn
+	w.connMu.RUnlock()
+
+	if currentConn != nil {
+		return currentConn, nil
+	}
+
+	// Looks like we might need to connect - try again with write locking.
+	w.connMu.Lock()
+	defer w.connMu.Unlock()
+	if w.conn != nil {
+		return w.conn, nil
+	}
+
+	newConn, err := net.Dial(w.addr.Network(), w.addr.String())
+	if err != nil {
+		return nil, err
+	}
+	w.conn = newConn
+	return newConn, nil
+}
+
+func (w *udsWriter) unsetConnection() {
+	w.connMu.Lock()
+	defer w.connMu.Unlock()
+	w.conn = nil
+}

--- a/datadog/uds.go
+++ b/datadog/uds.go
@@ -31,7 +31,7 @@ func newUDSWriter(addr string) (*udsWriter, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Defer connection to first Write
+	// Defer connection to first read/write
 	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: defaultUDSTimeout}
 	return writer, nil
 }

--- a/datadog/uds_test.go
+++ b/datadog/uds_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestUDSReconnectWhenConnRefused(t *testing.T) {
+func TestUDSReconnectsWhenConnRefused(t *testing.T) {
 	dir, err := ioutil.TempDir("", "socket")
 	if err != nil {
 		t.Error(err)

--- a/datadog/uds_test.go
+++ b/datadog/uds_test.go
@@ -1,0 +1,55 @@
+package datadog
+
+import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func TestUDSReconnectWhenConnRefused(t *testing.T) {
+	dir, err := ioutil.TempDir("", "socket")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	socketPath := filepath.Join(dir, "dsd.socket")
+	count := int32(0)
+	closerServer1 := startUDSTestServerWithSocketFile(t, socketPath, HandlerFunc(func(m Metric, _ net.Addr) {
+		atomic.AddInt32(&count, 1)
+	}))
+	defer closerServer1.Close()
+
+	client := NewClientWith(ClientConfig{
+		Address:    "unixgram://" + socketPath,
+		BufferSize: 1, // small buffer to force write to unix socket for each measure
+	})
+
+	measure := `main.http.error.count:0|c|#http_req_content_charset:,http_req_content_endoing:,http_req_content_type:,http_req_host:localhost:3011,http_req_method:GET,http_req_protocol:HTTP/1.1,http_req_transfer_encoding:identity
+`
+
+	_, err = client.Write([]byte(measure))
+	if err != nil {
+		t.Errorf("unable to write data %v", err)
+	}
+
+	closerServer1.Close()
+
+	_, err = client.Write([]byte(measure))
+	if err == nil {
+		t.Errorf("invalid error expected none, got %v", err)
+	}
+	// restart UDS server with same socket file
+	closerServer2 := startUDSTestServerWithSocketFile(t, socketPath, HandlerFunc(func(m Metric, _ net.Addr) {
+		atomic.AddInt32(&count, 1)
+	}))
+
+	defer closerServer2.Close()
+
+	_, err = client.Write([]byte(measure))
+	if err != nil {
+		t.Errorf("unable to write data but should be able to as the client should reconnect %v", err)
+	}
+
+}


### PR DESCRIPTION
### Goal

Adds Support for connecting to datadog via Unix Domain socket  (UDS) instead of UDP

### Why
UDS could be useful :
```
* Bypassing the networking stack brings a significant performance improvement for high traffic.
* While UDP has no error handling, UDS allows the Agent to detect dropped packets and connection errors, while still allowing a non-blocking use.
* DogStatsD can detect the container from which metrics originated and tag those metrics accordingly.
```
Taken from https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=host ^

### Usage to connect to `unixgram` socket instead of `udp`

```
client := NewClient("unixgram:///dir/filename.sock") // unixgram
```
instead of 

```
client := NewClient("localhost:8125") // udp
```

### What

I hope this PR could be useful, completely open for feedbacks to align this PR to the conventions/style of this library. I gave it a first shot.
I inlined comments/questions

### Credit

Datadog [official client lib](https://github.com/DataDog/datadog-go/blob/3255e6186e83fad1e447573c9fa03dd13c023394/statsd/uds.go) , i inspired a lot the code from it.
