### PR TITLE
Skip tag sort if possible in Report / ReportAt

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -100,7 +100,9 @@ func (b *tagsBuffer) reset() {
 }
 
 func (b *tagsBuffer) sort() {
-	sort.Sort(&b.tags)
+	if !TagsAreSorted(b.tags) {
+		SortTags(b.tags)
+	}
 }
 
 func (b *tagsBuffer) append(tags ...Tag) {

--- a/tag_test.go
+++ b/tag_test.go
@@ -220,3 +220,51 @@ func BenchmarkSortTagsMany(b *testing.B) {
 		SortTags(t1)
 	}
 }
+
+func BenchmarkTagsBufferSortSorted(b *testing.B) {
+	tags := []Tag{
+		{"A", ""},
+		{"B", ""},
+		{"C", ""},
+		{"answer", "42"},
+		{"answer", "42"},
+		{"hello", "world"},
+		{"hello", "world"},
+		{"some long tag name", "!"},
+		{"some long tag name", "!"},
+		{"some longer tag name", "1234"},
+	}
+
+	buf := tagsBuffer{
+		tags: make([]Tag, len(tags)),
+	}
+
+	for i := 0; i < b.N; i++ {
+		copy(buf.tags, tags)
+		buf.sort()
+	}
+}
+
+func BenchmarkTagsBufferSortUnsorted(b *testing.B) {
+	tags := []Tag{
+		{"some long tag name", "!"},
+		{"some longer tag name", "1234"},
+		{"hello", "world"},
+		{"C", ""},
+		{"answer", "42"},
+		{"hello", "world"},
+		{"B", ""},
+		{"answer", "42"},
+		{"some long tag name", "!"},
+		{"A", ""},
+	}
+
+	buf := tagsBuffer{
+		tags: make([]Tag, len(tags)),
+	}
+
+	for i := 0; i < b.N; i++ {
+		copy(buf.tags, tags)
+		buf.sort()
+	}
+}


### PR DESCRIPTION
This is the codepath used by Report() / ReportAt(), which is the fast path for reporting stats in v4. Skipping the sort saves us some work:

    benchmark                              old ns/op     new ns/op     delta
    BenchmarkTagsBufferSortSorted-12       107           49.3          -53.93%
    BenchmarkTagsBufferSortUnsorted-12     270           271           +0.37%

While users are less likely to have already-sorted stat tags in this case (because the tagsBuffer tag slice is built on every call and doesn't retain its sort between calls the way that you would retain sorted engine tags if you were calling stats.Incr() without tags often), it can show up in benchmarks and guide users toward this little cheat by passing in their tags in sorted order.
