### PR TITLE
add comment in clock.go indicating the time.duration unit reported to datadog

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -6,6 +6,8 @@ import "time"
 //
 // Clocks are useful to measure the duration taken by sequential execution steps
 // and therefore aren't safe to be used concurrently by multiple goroutines.
+//
+// Note: Clock times are reported to datadog in seconds. See `stats/datadog/measure.go`.
 type Clock struct {
 	name  string
 	first time.Time


### PR DESCRIPTION
It's hard to find the units that are sent to datadog using stats.Clock.

E.g. https://segment.slack.com/archives/G3MBGVCM9/p1614973096005100

Adding a comment for easier reference.