### PR TITLE
Fix use of reflect.StringHeader in prometheus/metric.go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: /go/src/github.com/segmentio/stats
     docker:
       - image: circleci/golang
-      - image: influxdb:alpine
+      - image: influxdb:1.8.9-alpine
         ports: ['8086:8086']
     steps:
       - checkout

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -402,10 +402,15 @@ func le(buckets []stats.Value) string {
 		b = appendFloat(b, valueOf(v))
 	}
 
-	return *(*string)(unsafe.Pointer(&reflect.StringHeader{
-		Data: uintptr(unsafe.Pointer(&b[0])),
-		Len:  len(b),
-	}))
+	// This code block converts the byte array to a string without additional
+	// memory allocation.
+	// Source: https://stackoverflow.com/a/66865482 (license: CC BY-SA 4.0)
+	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	var s string
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	sh.Data = sliceHeader.Data
+	sh.Len = sliceHeader.Len
+	return s
 }
 
 func nextLe(s string) (head string, tail string) {

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -404,7 +404,7 @@ func le(buckets []stats.Value) string {
 	return unsafeByteSliceToString(b)
 }
 
-// This code block converts the byte array to a string without additional
+// This function converts the byte array to a string without additional
 // memory allocation.
 // Source: https://stackoverflow.com/a/66865482 (license: CC BY-SA 4.0)
 func unsafeByteSliceToString(b []byte) string {

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -401,10 +401,13 @@ func le(buckets []stats.Value) string {
 		}
 		b = appendFloat(b, valueOf(v))
 	}
+	return unsafeByteSliceToString(b)
+}
 
-	// This code block converts the byte array to a string without additional
-	// memory allocation.
-	// Source: https://stackoverflow.com/a/66865482 (license: CC BY-SA 4.0)
+// This code block converts the byte array to a string without additional
+// memory allocation.
+// Source: https://stackoverflow.com/a/66865482 (license: CC BY-SA 4.0)
+func unsafeByteSliceToString(b []byte) string {
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	var s string
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -28,15 +28,25 @@ func TestUnsafeByteSliceToString(t *testing.T) {
 			expected: "",
 		},
 		{
+			name:     "list of floats",
+			input:    []byte("1.2:3.4:5.6:7.8"),
+			expected: "1.2:3.4:5.6:7.8",
+		},
+		{
 			name:     "deadbeef",
 			input:    []byte{0xde, 0xad, 0xbe, 0xef},
-			expected: "deadbeef",
+			expected: "\xde\xad\xbe\xef",
+		},
+		{
+			name:     "embedded zero",
+			input:    []byte("this\x00that"),
+			expected: "this\x00that",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			res := unsafeByteSliceToString(test.input)
 			if res != test.expected {
-				t.Errorf("Expected %q but got %q", test.expected, tes)
+				t.Errorf("Expected %q but got %q", test.expected, res)
 			}
 		})
 	}

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -11,6 +11,37 @@ import (
 	"github.com/segmentio/stats/v4"
 )
 
+func TestUnsafeByteSliceToString(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "nil bytes",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "no bytes",
+			input:    []byte{},
+			expected: "",
+		},
+		{
+			name:     "deadbeef",
+			input:    []byte{0xde, 0xad, 0xbe, 0xef},
+			expected: "deadbeef",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			res := unsafeByteSliceToString(test.input)
+			if res != test.expected {
+				t.Errorf("Expected %q but got %q", test.expected, tes)
+			}
+		})
+	}
+}
+
 func TestMetricStore(t *testing.T) {
 	input := []metric{
 		{mtype: counter, scope: "test", name: "A", value: 1},


### PR DESCRIPTION
The `go vet` command in Go 1.16 reports a warning for inappropriate
use of reflect.StringHeader.

https://github.com/golang/go/issues/40701

Its use in prometheus/metric.go to convert a byte array to a string in
place began to trigger the warning. That code has been replaced with a
safer variant that avoids the `vet` warning and still converts the array
without allocating new memory.

https://stackoverflow.com/a/66865482