### PR TITLE
emit metrics for deadline_exceeded

### DIFF
--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -160,6 +161,12 @@ func (c *conn) SetWriteDeadline(t time.Time) (err error) {
 
 func (c *conn) error(op string, err error) {
 	switch err = rootError(err); err {
+	case os.ErrDeadlineExceeded:
+		c.eng.Incr("conn.error.count",
+			stats.T("operation", op),
+			stats.T("protocol", c.w.metrics.protocol),
+			stats.T("error", "deadline_exceeded"),
+		)
 	case io.EOF, io.ErrClosedPipe, io.ErrUnexpectedEOF:
 		// this is expected to happen when connections are closed
 	default:


### PR DESCRIPTION
When Go HTTP Server's timeouts are set and are exceeded, read/write will return the `os.ErrDeadlineExceeded` error and this causes the ALB to return a 502. This PR tags `conn.error.count` metrics with `error=deadline_exceeded` when the error is `os.ErrDeadlineExceeded`. This allows better visibility when ALB shows 502 errors.

