### PR TITLE
switch all main-ish branch references to be literally main

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,7 @@ name: golangci-lint
   push:
     tags:
       - v*
-    branches: [master]
+    branches: [main]
     paths:
       - '**.go'
       - .golangci.yml


### PR DESCRIPTION
This is in preparation for switching the default branch name to main.
