### PR TITLE
syscall.Sysinfo returns an uint32 on linux/arm, but uint64 otherwise

### DIFF
--- a/procstats/linux/memory_linux.go
+++ b/procstats/linux/memory_linux.go
@@ -57,7 +57,8 @@ func readSysinfoMemoryLimit() (limit uint64, err error) {
 	var sysinfo syscall.Sysinfo_t
 
 	if err = syscall.Sysinfo(&sysinfo); err == nil {
-		limit = uint64(sysinfo.Unit) * sysinfo.Totalram
+		// syscall.Sysinfo returns an uint32 on linux/arm, but uint64 otherwise
+		limit = uint64(sysinfo.Unit) * uint64(sysinfo.Totalram)
 	}
 
 	return


### PR DESCRIPTION
Seems like the syscall result isn't the same between arm (32bit) and arm64. Totalram can be an uint32. Instead of creating an additional build constraint, I just added the cast which will be removed when unnecessary, but stays in place when required.