### PR TITLE
tag: fix build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/segmentio/objconv v1.0.1
 	github.com/segmentio/vpcinfo v0.1.10
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	golang.org/x/sync v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072 h1:7YEPiUVGht4Z
 github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072/go.mod h1:sGdS7A6CAETR53zkdjGkgoFlh1vSm7MtX+i8XfEsTMA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
-github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
@@ -26,8 +24,8 @@ github.com/segmentio/vpcinfo v0.1.10/go.mod h1:KEIWiWRE/KLh90mOzOY0QkFWT7ObUYLp9
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=

--- a/procstats/linux/cgroup_linux_test.go
+++ b/procstats/linux/cgroup_linux_test.go
@@ -7,6 +7,7 @@
 package linux
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -51,6 +52,12 @@ func TestParseProcCGroup(t *testing.T) {
 	}
 }
 
+func sysGone(t *testing.T) bool {
+	t.Helper()
+	_, err := os.Stat("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+	return os.IsNotExist(err)
+}
+
 func TestProcCGroupLookup(t *testing.T) {
 	tests := []struct {
 		proc   ProcCGroup
@@ -81,6 +88,9 @@ func TestProcCGroupLookup(t *testing.T) {
 }
 
 func TestReadCPUPeriod(t *testing.T) {
+	if sysGone(t) {
+		t.Skip("/sys files not available on this filesystem; skipping test")
+	}
 	period, err := ReadCPUPeriod("")
 	if err != nil {
 		t.Fatal(err)
@@ -91,6 +101,9 @@ func TestReadCPUPeriod(t *testing.T) {
 }
 
 func TestReadCPUQuota(t *testing.T) {
+	if sysGone(t) {
+		t.Skip("/sys files not available on this filesystem; skipping test")
+	}
 	quota, err := ReadCPUQuota("")
 	if err != nil {
 		t.Fatal(err)
@@ -101,6 +114,9 @@ func TestReadCPUQuota(t *testing.T) {
 }
 
 func TestReadCPUShares(t *testing.T) {
+	if sysGone(t) {
+		t.Skip("/sys files not available on this filesystem; skipping test")
+	}
 	shares, err := ReadCPUShares("")
 	if err != nil {
 		t.Fatal(err)

--- a/procstats/linux/io.go
+++ b/procstats/linux/io.go
@@ -2,7 +2,7 @@ package linux
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -10,7 +10,7 @@ import (
 )
 
 func readFile(path string) string {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	check(err)
 	return string(b)
 }

--- a/procstats/linux/memory_linux.go
+++ b/procstats/linux/memory_linux.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,7 +32,7 @@ func readProcCGroupMemoryLimit(cgroups ProcCGroup) (limit uint64) {
 func readMemoryCGroupMemoryLimit(cgroup CGroup) (limit uint64) {
 	limit = unlimitedMemoryLimit // default value if something doesn't work
 
-	if b, err := ioutil.ReadFile(readMemoryCGroupMemoryLimitFilePath(cgroup.Path)); err == nil {
+	if b, err := os.ReadFile(readMemoryCGroupMemoryLimitFilePath(cgroup.Path)); err == nil {
 		if v, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil {
 			limit = v
 		}

--- a/procstats/linux/memory_linux_test.go
+++ b/procstats/linux/memory_linux_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestReadMemoryLimit(t *testing.T) {
+	if sysGone(t) {
+		t.Skip("/sys files not available on this filesystem; skipping test")
+	}
 	if limit, err := ReadMemoryLimit(os.Getpid()); err != nil {
 		t.Error(err)
 

--- a/tag.go
+++ b/tag.go
@@ -51,14 +51,13 @@ func SortTags(tags []Tag) []Tag {
 	return deduplicateTags(tags)
 }
 
+// reports whether a is less than b
 func tagCompare(a, b Tag) int {
-	switch {
-	case a.Name < b.Name:
+	if a.Name < b.Name {
 		return -1
-	case a.Name > b.Name:
-		return +1
+	} else if b.Name < a.Name {
+		return 1
 	}
-
 	return 0
 }
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -190,7 +190,7 @@ func BenchmarkTagsOrder(b *testing.B) {
 
 func tagIsLessByIndex(tags []Tag) func(int, int) bool {
 	return func(i, j int) bool {
-		return tagCompare(tags[i], tags[j]) < 0
+		return tagCompare(tags[i], tags[j]) == -1
 	}
 }
 


### PR DESCRIPTION
On tip (the Go 1.22 code freeze), Go reports that `compareTag` has the wrong method signature:

```
type func(a Tag, b Tag) int of tagCompare does not match inferred type func(a Tag, b Tag) bool for func(a E, b E) bool
```

Fix this by using the correct method signature.