### PR TITLE
procstats: fix tests on Macs

### DIFF
--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -187,9 +187,17 @@ type ProcInfo struct {
 	Threads ThreadInfo
 }
 
-// CollectProcInfo return a ProcInfo and error (if any) for a given PID.
+// CollectProcInfo returns a ProcInfo and error (if any) for a given PID.
 func CollectProcInfo(pid int) (ProcInfo, error) {
 	return collectProcInfo(pid)
+}
+
+type OSUnsupportedError struct {
+	Msg string
+}
+
+func (o *OSUnsupportedError) Error() string {
+	return o.Msg
 }
 
 // CPUInfo holds statistics and configuration details for a process.

--- a/procstats/proc_darwin.go
+++ b/procstats/proc_darwin.go
@@ -23,7 +23,6 @@ static mach_port_t mach_task_self() { return mach_task_self_; }
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -35,7 +34,7 @@ func collectProcInfo(pid int) (info ProcInfo, err error) {
 	defer func() { err = convertPanicToError(recover()) }()
 
 	if pid != os.Getpid() {
-		panic(errors.New("on darwin systems only metrics of the current process can be collected"))
+		panic(&OSUnsupportedError{Msg: "on darwin systems only metrics of the current process can be collected"})
 	}
 
 	self := C.mach_port_name_t(C.mach_task_self())


### PR DESCRIPTION
Previously they would fail with an anticipated error; instead, skip the failing test on Darwin.