### PR TITLE
engine: report go version on startup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,6 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	go test -trimpath ./...
+
+ci:
+	go test -race -trimpath ./...
+
+lint:
+	golangci-lint run --config .golangci.yml

--- a/README.md
+++ b/README.md
@@ -385,3 +385,16 @@ func main() {
     // ...
 }
 ```
+
+### Addendum
+
+By default, the stats library will report the running go version when you
+invoke NewEngine() as three metrics:
+
+- `go_version.major`
+- `go_version.minor`
+- `go_version.patch`
+
+Set `STATS_DISABLE_GO_VERSION_REPORTING` to `true` in your environment, or set
+`stats.GoVersionReportingEnabled` to `false` before collecting any metrics, to
+disable this behavior.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Monitoring
 
 > 🚧 Go metrics reported with the `procstats` package were previously tagged with a
 > `version` label that reported the Go runtime version. This label was renamed to
-> `go_version` in v5.6.0.
+> `go_version` in v4.6.0.
 
 The
 [github.com/segmentio/stats/procstats](https://godoc.org/github.com/segmentio/stats/procstats)
@@ -389,11 +389,11 @@ func main() {
 ### Addendum
 
 By default, the stats library will report the running go version when you
-invoke NewEngine() as three metrics:
+invoke NewEngine() as a metric:
 
-- `go_version.major`
-- `go_version.minor`
-- `go_version.patch`
+- `go_version` with value 1 and a `tag` set to the current version.
+- `stats_version` with value ` and a `tag` set to the tag value of
+  segmentio/stats.
 
 Set `STATS_DISABLE_GO_VERSION_REPORTING` to `true` in your environment, or set
 `stats.GoVersionReportingEnabled` to `false` before collecting any metrics, to

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/datadog"
 )
 

--- a/context.go
+++ b/context.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ContextWithTags returns a new child context with the given tags.  If the
-// parent context already has tags set on it, they are _not_ propegated into
+// parent context already has tags set on it, they are _not_ propagated into
 // the context children.
 func ContextWithTags(ctx context.Context, tags ...Tag) context.Context {
 	// initialize the context reference and return a new context

--- a/datadog/append.go
+++ b/datadog/append.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func appendMetric(b []byte, m Metric) []byte {

--- a/datadog/client.go
+++ b/datadog/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 
 	"golang.org/x/sys/unix"
 )

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/datadog/event.go
+++ b/datadog/event.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"fmt"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // EventPriority is an enumeration providing the available datadog event

--- a/datadog/event_test.go
+++ b/datadog/event_test.go
@@ -1,7 +1,7 @@
 package datadog
 
 import (
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 var testEvents = []struct {

--- a/datadog/metric.go
+++ b/datadog/metric.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // MetricType is an enumeration providing symbols to represent the different

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"testing"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 var testMetrics = []struct {

--- a/datadog/parse.go
+++ b/datadog/parse.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // Adapted from https://github.com/DataDog/datadog-agent/blob/6789e98a1e41e98700fa1783df62238bb23cb454/pkg/dogstatsd/parser.go#L141

--- a/datadog/serializer.go
+++ b/datadog/serializer.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // Datagram format: https://docs.datadoghq.com/developers/dogstatsd/datagram_shell

--- a/datadog/serializer_test.go
+++ b/datadog/serializer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 var testMeasures = []struct {

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	initValue := stats.GoVersionReportingEnabled
+	stats.GoVersionReportingEnabled = false
+	defer func() { stats.GoVersionReportingEnabled = initValue }()
 	engine := stats.NewEngine("datadog.test", nil)
 
 	a := uint32(0)
@@ -97,6 +100,7 @@ func TestServer(t *testing.T) {
 }
 
 func startUDPTestServer(t *testing.T, handler Handler) (addr string, closer io.Closer) {
+	t.Helper()
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		t.Error(err)

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func TestServer(t *testing.T) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/datadog"
 	"github.com/segmentio/stats/v5/influxdb"
 	"github.com/segmentio/stats/v5/prometheus"

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/segmentio/stats/v5
 
 go 1.22.0
 
-toolchain go1.23.1
-
 require (
 	github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072
 	github.com/segmentio/fasthash v1.0.3

--- a/handler_test.go
+++ b/handler_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 
 	"github.com/stretchr/testify/assert"

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -3,7 +3,7 @@ package httpstats
 import (
 	"net/http"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // RequestWithTags returns a shallow copy of req with its context updated to

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -6,17 +6,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	stats "github.com/segmentio/stats/v5"
 
-	"github.com/segmentio/stats/v5"
+	"github.com/stretchr/testify/assert"
 )
 
-// TestRequestContextTagPropegation verifies that the root ancestor tags are
+// TestRequestContextTagPropagation verifies that the root ancestor tags are
 // updated in the event the context or request has children.  It's nearly
 // identical to the context_test in the stats package itself, but we want to
 // keep this to ensure that changes to the request context code doesn't drift
 // and cause bugs.
-func TestRequestContextTagPropegation(t *testing.T) {
+func TestRequestContextTagPropagation(t *testing.T) {
 	// dummy request
 	x := httptest.NewRequest(http.MethodGet, "http://example.com/blah", nil)
 

--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // NewHandler wraps h to produce metrics on the default engine for every request

--- a/httpstats/handler_test.go
+++ b/httpstats/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // NewTransport wraps t to produce metrics on the default engine for every request

--- a/httpstats/transport_test.go
+++ b/httpstats/transport_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 

--- a/influxdb/client.go
+++ b/influxdb/client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/segmentio/objconv/json"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 const (

--- a/influxdb/client_test.go
+++ b/influxdb/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func DisabledTestClient(t *testing.T) {

--- a/influxdb/measure.go
+++ b/influxdb/measure.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // AppendMeasure is a formatting routine to append the InflxDB line protocol

--- a/influxdb/measure_test.go
+++ b/influxdb/measure_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 var (

--- a/measure.go
+++ b/measure.go
@@ -504,9 +504,9 @@ func (c *measureCache) load() *map[reflect.Type][]measureFuncs {
 	return (*map[reflect.Type][]measureFuncs)(atomic.LoadPointer(&c.cache))
 }
 
-func (c *measureCache) compareAndSwap(old, new *map[reflect.Type][]measureFuncs) bool {
+func (c *measureCache) compareAndSwap(old, newPtr *map[reflect.Type][]measureFuncs) bool {
 	return atomic.CompareAndSwapPointer(&c.cache,
 		unsafe.Pointer(old),
-		unsafe.Pointer(new),
+		unsafe.Pointer(newPtr),
 	)
 }

--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/segmentio/vpcinfo"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 

--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -23,6 +23,9 @@ func TestBaseConn(t *testing.T) {
 }
 
 func TestConn(t *testing.T) {
+	initValue := stats.GoVersionReportingEnabled
+	stats.GoVersionReportingEnabled = false
+	defer func() { stats.GoVersionReportingEnabled = initValue }()
 	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
@@ -84,6 +87,9 @@ func TestConn(t *testing.T) {
 }
 
 func TestConnError(t *testing.T) {
+	initValue := stats.GoVersionReportingEnabled
+	stats.GoVersionReportingEnabled = false
+	defer func() { stats.GoVersionReportingEnabled = initValue }()
 	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 

--- a/netstats/handler.go
+++ b/netstats/handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // Handler is an interface that can be implemented by types that serve network

--- a/netstats/listener.go
+++ b/netstats/listener.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // NewListener returns a new net.Listener which uses the stats.DefaultEngine.

--- a/netstats/listener_test.go
+++ b/netstats/listener_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 
@@ -66,10 +66,24 @@ func TestListenerError(t *testing.T) {
 	vsn := strings.TrimPrefix(runtime.Version(), "go")
 	parts := strings.Split(vsn, ".")
 	measures := h.Measures()
+	measurePassed := false
 	if len(parts) == 2 || len(parts) == 3 {
-		if len(measures) != 1+1 {
-			t.Fatalf("expecting to get %d metrics, got back %d: %v", 1+1, len(measures), measures)
+		for _, measure := range measures {
+			if measure.Name != "go_version" {
+				continue
+			}
+			for _, tag := range measure.Tags {
+				if tag.Name != "go_version" {
+					continue
+				}
+				if tag.Value == vsn {
+					measurePassed = true
+				}
+			}
 		}
+	}
+	if !measurePassed {
+		t.Errorf("did not find correct tag for measure: %#v\n", measures)
 	}
 	var foundMetric stats.Measure
 	for i := range measures {

--- a/netstats/listener_test.go
+++ b/netstats/listener_test.go
@@ -3,6 +3,8 @@ package netstats
 import (
 	"net"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/segmentio/stats/v5"
@@ -10,6 +12,9 @@ import (
 )
 
 func TestListener(t *testing.T) {
+	initValue := stats.GoVersionReportingEnabled
+	stats.GoVersionReportingEnabled = false
+	defer func() { stats.GoVersionReportingEnabled = initValue }()
 	h := &statstest.Handler{}
 	e := stats.NewEngine("netstats.test", h)
 
@@ -58,15 +63,31 @@ func TestListenerError(t *testing.T) {
 
 	lstn.Close()
 
-	expected := []stats.Measure{
-		{
-			Name:   "netstats.test.conn.error",
-			Fields: []stats.Field{stats.MakeField("count", 1, stats.Counter)},
-			Tags:   []stats.Tag{stats.T("operation", "accept"), stats.T("protocol", "tcp")},
-		},
+	vsn := strings.TrimPrefix(runtime.Version(), "go")
+	parts := strings.Split(vsn, ".")
+	measures := h.Measures()
+	if len(parts) == 2 || len(parts) == 3 {
+		if len(measures) != 1+1 {
+			t.Fatalf("expecting to get %d metrics, got back %d: %v", 1+1, len(measures), measures)
+		}
+	}
+	var foundMetric stats.Measure
+	for i := range measures {
+		if measures[i].Name == "netstats.test.conn.error" {
+			foundMetric = measures[i]
+			break
+		}
+	}
+	if foundMetric.Name == "" {
+		t.Errorf("did not find netstats metric: %v", measures)
 	}
 
-	if !reflect.DeepEqual(expected, h.Measures()) {
+	expected := stats.Measure{
+		Name:   "netstats.test.conn.error",
+		Fields: []stats.Field{stats.MakeField("count", 1, stats.Counter)},
+		Tags:   []stats.Tag{stats.T("operation", "accept"), stats.T("protocol", "tcp")},
+	}
+	if !reflect.DeepEqual(expected, foundMetric) {
 		t.Error("bad measures:")
 		t.Logf("expected: %v", expected)
 		t.Logf("found:    %v", h.Measures())

--- a/procstats/collector_test.go
+++ b/procstats/collector_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 

--- a/procstats/delaystats.go
+++ b/procstats/delaystats.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // DelayMetrics is a metric collector that reports resource delays on processes.

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -109,7 +109,7 @@ func NewGoMetrics() *GoMetrics {
 	return NewGoMetricsWith(stats.DefaultEngine)
 }
 
-// NewGoMetricsWith creates a new collector for the Go unrtime that producers
+// NewGoMetricsWith creates a new collector for the Go runtime that producers
 // metrics on eng.
 func NewGoMetricsWith(eng *stats.Engine) *GoMetrics {
 	g := &GoMetrics{

--- a/procstats/go_test.go
+++ b/procstats/go_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/statstest"
 )
 

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 // ProcMetrics is a metric collector that reports metrics on processes.

--- a/statstest/handler.go
+++ b/statstest/handler.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 )
 
 var (

--- a/veneur/client.go
+++ b/veneur/client.go
@@ -3,7 +3,7 @@ package veneur
 import (
 	"time"
 
-	"github.com/segmentio/stats/v5"
+	stats "github.com/segmentio/stats/v5"
 	"github.com/segmentio/stats/v5/datadog"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "5.1.0"


### PR DESCRIPTION
The first time you report any metric, additionally report the running Go version. Add two flags that can be used to disable this behavior.