### PR TITLE
Introduce a flag that skips tag duplicate removal logic

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -38,10 +38,9 @@ func TagsAreSorted(tags []Tag) bool {
 	return slices.IsSortedFunc(tags, tagCompare)
 }
 
-// SortTags sorts and deduplicates tags in-place,
-// favoring later elements whenever a tag name duplicate occurs.
-// The returned slice may be shorter than the input
-// due to the elimination of duplicates.
+// SortTags sorts and deduplicates tags in-place, favoring later elements
+// whenever a tag name duplicate occurs. The returned slice may be shorter than
+// the input due to the elimination of duplicates.
 func SortTags(tags []Tag) []Tag {
 	// Stable sort ensures that we have deterministic
 	// "latest wins" deduplication.


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `Engine` struct in `engine.go` which allows the skipping of duplicate tag removal in the metrics reporting process. This feature is tested in `engine_test.go`. 

The most important changes are:

New feature:

* [`engine.go`](diffhunk://#diff-faa39773718bee2c453eb6825bcc4dc5766eff99ab928f1827ddba95d18d15e2R32-R37): Added a new boolean field `SkipTagDuplicateRemoval` to the `Engine` struct. This field controls whether the engine should skip the removal of duplicate tags from the tags list before sending.

Feature integration:

* [`engine.go`](diffhunk://#diff-faa39773718bee2c453eb6825bcc4dc5766eff99ab928f1827ddba95d18d15e2L151-R157): Modified the `measure` and `ReportAt` methods of the `Engine` struct to check the `SkipTagDuplicateRemoval` field before removing duplicate tags. [[1]](diffhunk://#diff-faa39773718bee2c453eb6825bcc4dc5766eff99ab928f1827ddba95d18d15e2L151-R157) [[2]](diffhunk://#diff-faa39773718bee2c453eb6825bcc4dc5766eff99ab928f1827ddba95d18d15e2R201-R203)

Testing:

* [`engine_test.go`](diffhunk://#diff-561312ff39c4286c086ab2f700d5834b03027fcbfb96c9a526b3e7bfb77782cfR71-R74): Added a new test scenario in `TestEngine` to test the behavior when `SkipTagDuplicateRemoval` is set.
* [`engine_test.go`](diffhunk://#diff-561312ff39c4286c086ab2f700d5834b03027fcbfb96c9a526b3e7bfb77782cfR133-R155): Implemented a new test function `testEngineSkipTagDuplicateRemoval` to test the new feature.


### Contexts

![image](https://github.com/user-attachments/assets/6857c24c-de9a-4af5-8c9e-f8ebbc0a7916)

https://twilio.slack.com/archives/CPLTV1V9A/p1720735336325819