### PR TITLE
docker-compose.yml: specify AMD64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,28 @@ services:
   influxdb:
     image: influxdb:alpine
     ports:
-      - 8086:8086
-  
+    - 8086:8086
+
+    # If you are on arm64 and experiencing issues with the tests (hangs,
+    # connection reset) then try the following in order:
+
+    # - stopping and removing all downloaded container images
+    # - ensuring you have the latest Docker Desktop version
+    # - factory reset your Docker Desktop settings
+
+    # If you are still running into issues please post in #help-infra-seg.
+    platform: linux/amd64
   otel-collector:
     image: otel/opentelemetry-collector:0.48.0
     command:
-      - "/otelcol"
-      - "--config=/etc/otel-config.yaml"
+    - "/otelcol"
+    - "--config=/etc/otel-config.yaml"
     ports:
-      - 4317:4317
-      - 4318:4318
-      - 4319:4319
-      - 8888:8888
+    - 4317:4317
+    - 4318:4318
+    - 4319:4319
+    - 8888:8888
     volumes:
-      - "./.otel/config.yaml:/etc/otel-config.yaml"
+    - "./.otel/config.yaml:/etc/otel-config.yaml"
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64


### PR DESCRIPTION
Several Docker images used by Segment do not work reliably on Mac M1 laptops,
which use the arm64 chipset. Commonly, these are images that were built several
years ago, before M1 laptops were in widespread use, and behave unpredictably
when run on an arm64 chipset.

The simplest workaround is to ensure that the Docker environment is always
running on amd64. If this service runs on Graviton instances (which use the
arm64 chipset), then you should close this PR, or reverse the "platform" to
instead specify "linux/arm64".

This change should ensure that employees with Apple M1 laptops will be able to
reliably start and run Docker containers on this repository.

This commit may include some whitespace-only changes, which are an
artifact of the comment-preserving YAML parser that was used to modify the
docker-compose.yml file. To exclude these from the diff, append ?w=1 to the pull
request URL.

If the pull request build fails with this error:

	Unsupported config option for services.mysql: 'platform'

Replace all references to "docker-compose" in the repo with "docker compose",
which has additional functionality, and is easier to keep up to date. (This is
something that you should do anyway, even without merging this PR).

This pull request was generated by a script run by Kevin Burke. There are over
300 docker-compose files at Segment and he would appreciate your help testing
and merging this pull request. At this scale, it is not possible to satisfy
every repository's rules for formatting, labeling, and testing pull requests.

If you have questions, please post in #help-infra-seg.
JIRA: https://segment.atlassian.net/browse/IO-2101
