### PR TITLE
all: update v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Installation
 ------------
 
 ```
-go get github.com/segmentio/stats/v4
+go get github.com/segmentio/stats/v5
 ```
 
-Migration to v4
+Migration to v5
 ---------------
 
 Version 4 of the stats package introduced a new way of producing metrics based
@@ -101,8 +101,8 @@ collection platforms.
 package main
 
 import (
-    "github.com/segmentio/stats/v4"
-    "github.com/segmentio/stats/v4/datadog"
+    "github.com/segmentio/stats/v5"
+    "github.com/segmentio/stats/v5/datadog"
 )
 
 func main() {
@@ -132,8 +132,8 @@ func main() {
 package main
 
 import (
-    "github.com/segmentio/stats/v4"
-    "github.com/segmentio/stats/v4/datadog"
+    "github.com/segmentio/stats/v5"
+    "github.com/segmentio/stats/v5/datadog"
 )
 
 func main() {
@@ -183,7 +183,7 @@ Monitoring
 
 > 🚧 Go metrics reported with the `procstats` package were previously tagged with a
 > `version` label that reported the Go runtime version. This label was renamed to
-> `go_version` in v4.6.0.
+> `go_version` in v5.6.0.
 
 The
 [github.com/segmentio/stats/procstats](https://godoc.org/github.com/segmentio/stats/procstats)
@@ -197,8 +197,8 @@ Here's an example of how to use the collector:
 package main
 
 import (
-    "github.com/segmentio/stats/v4/datadog"
-    "github.com/segmentio/stats/v4/procstats"
+    "github.com/segmentio/stats/v5/datadog"
+    "github.com/segmentio/stats/v5/procstats"
 )
 
 
@@ -245,8 +245,8 @@ package main
 import (
     "net/http"
 
-    "github.com/segmentio/stats/v4/datadog"
-    "github.com/segmentio/stats/v4/httpstats"
+    "github.com/segmentio/stats/v5/datadog"
+    "github.com/segmentio/stats/v5/httpstats"
 )
 
 func main() {
@@ -279,8 +279,8 @@ package main
 import (
     "net/http"
 
-    "github.com/segmentio/stats/v4/datadog"
-    "github.com/segmentio/stats/v4/httpstats"
+    "github.com/segmentio/stats/v5/datadog"
+    "github.com/segmentio/stats/v5/httpstats"
 )
 
 func main() {
@@ -308,8 +308,8 @@ package main
 import (
     "net/http"
 
-    "github.com/segmentio/stats/v4/datadog"
-    "github.com/segmentio/stats/v4/httpstats"
+    "github.com/segmentio/stats/v5/datadog"
+    "github.com/segmentio/stats/v5/httpstats"
 )
 
 func main() {
@@ -342,7 +342,7 @@ package main
 
 import (
     "github.com/segmentio/redis-go"
-    "github.com/segmentio/stats/v4/redisstats"
+    "github.com/segmentio/stats/v5/redisstats"
 )
 
 func main() {
@@ -365,7 +365,7 @@ package main
 
 import (
     "github.com/segmentio/redis-go"
-    "github.com/segmentio/stats/v4/redisstats"
+    "github.com/segmentio/stats/v5/redisstats"
 )
 
 func main() {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/datadog"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/datadog"
 )
 
 func main() {

--- a/datadog/append.go
+++ b/datadog/append.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func appendMetric(b []byte, m Metric) []byte {

--- a/datadog/client.go
+++ b/datadog/client.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 
 	"golang.org/x/sys/unix"
 )
@@ -178,7 +178,7 @@ func dial(address string, sizehint int) (conn net.Conn, bufsize int, err error) 
 	}
 
 	// Even tho the buffer agrees to support a bigger size it shouldn't be
-	// possible to send datagrams larger than 65 KB on an IPv4 socket, so let's
+	// possible to send datagrams larger than 65 KB on an IPv5 socket, so let's
 	// enforce the max size.
 	if bufsize > MaxBufferSize {
 		bufsize = MaxBufferSize

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/datadog/event.go
+++ b/datadog/event.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"fmt"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // EventPriority is an enumeration providing the available datadog event

--- a/datadog/event_test.go
+++ b/datadog/event_test.go
@@ -1,7 +1,7 @@
 package datadog
 
 import (
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 var testEvents = []struct {

--- a/datadog/metric.go
+++ b/datadog/metric.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // MetricType is an enumeration providing symbols to represent the different

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"testing"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 var testMetrics = []struct {

--- a/datadog/parse.go
+++ b/datadog/parse.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // Adapted from https://github.com/DataDog/datadog-agent/blob/6789e98a1e41e98700fa1783df62238bb23cb454/pkg/dogstatsd/parser.go#L141

--- a/datadog/serializer.go
+++ b/datadog/serializer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // Datagram format: https://docs.datadoghq.com/developers/dogstatsd/datagram_shell

--- a/datadog/serializer_test.go
+++ b/datadog/serializer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 var testMeasures = []struct {

--- a/datadog/server_test.go
+++ b/datadog/server_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func TestServer(t *testing.T) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/datadog"
-	"github.com/segmentio/stats/v4/influxdb"
-	"github.com/segmentio/stats/v4/prometheus"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/datadog"
+	"github.com/segmentio/stats/v5/influxdb"
+	"github.com/segmentio/stats/v5/prometheus"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestEngine(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/stats/v4
+module github.com/segmentio/stats/v5
 
 go 1.18
 

--- a/grafana/grafanatest/annotations.go
+++ b/grafana/grafanatest/annotations.go
@@ -1,6 +1,6 @@
 package grafanatest
 
-import "github.com/segmentio/stats/v4/grafana"
+import "github.com/segmentio/stats/v5/grafana"
 
 // AnnotationsResponse is an implementation of the grafana.AnnotationsResponse
 // interface which captures the values passed to its method calls.

--- a/grafana/grafanatest/annotations_test.go
+++ b/grafana/grafanatest/annotations_test.go
@@ -1,5 +1,5 @@
 package grafanatest
 
-import "github.com/segmentio/stats/v4/grafana"
+import "github.com/segmentio/stats/v5/grafana"
 
 var _ grafana.AnnotationsResponse = (*AnnotationsResponse)(nil)

--- a/grafana/grafanatest/query.go
+++ b/grafana/grafanatest/query.go
@@ -3,7 +3,7 @@ package grafanatest
 import (
 	"time"
 
-	"github.com/segmentio/stats/v4/grafana"
+	"github.com/segmentio/stats/v5/grafana"
 )
 
 // QueryResponse is an implementation of the grafana.QueryResponse interface

--- a/grafana/grafanatest/query_test.go
+++ b/grafana/grafanatest/query_test.go
@@ -1,5 +1,5 @@
 package grafanatest
 
-import "github.com/segmentio/stats/v4/grafana"
+import "github.com/segmentio/stats/v5/grafana"
 
 var _ grafana.QueryResponse = (*QueryResponse)(nil)

--- a/grafana/grafanatest/search_test.go
+++ b/grafana/grafanatest/search_test.go
@@ -1,5 +1,5 @@
 package grafanatest
 
-import "github.com/segmentio/stats/v4/grafana"
+import "github.com/segmentio/stats/v5/grafana"
 
 var _ grafana.SearchResponse = (*SearchResponse)(nil)

--- a/handler_test.go
+++ b/handler_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/httpstats/context.go
+++ b/httpstats/context.go
@@ -3,7 +3,7 @@ package httpstats
 import (
 	"net/http"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // RequestWithTags returns a shallow copy of req with its context updated to

--- a/httpstats/context_test.go
+++ b/httpstats/context_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // TestRequestContextTagPropegation verifies that the root ancestor tags are

--- a/httpstats/handler.go
+++ b/httpstats/handler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // NewHandler wraps h to produce metrics on the default engine for every request

--- a/httpstats/handler_test.go
+++ b/httpstats/handler_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestHandler(t *testing.T) {

--- a/httpstats/metrics.go
+++ b/httpstats/metrics.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/httpstats/metrics_test.go
+++ b/httpstats/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v4/iostats"
+	"github.com/segmentio/stats/v5/iostats"
 )
 
 func TestResponseStatusBucket(t *testing.T) {

--- a/httpstats/transport.go
+++ b/httpstats/transport.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // NewTransport wraps t to produce metrics on the default engine for every request

--- a/httpstats/transport_test.go
+++ b/httpstats/transport_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestTransport(t *testing.T) {

--- a/influxdb/client.go
+++ b/influxdb/client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/segmentio/objconv/json"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 const (

--- a/influxdb/client_test.go
+++ b/influxdb/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func DisabledTestClient(t *testing.T) {

--- a/influxdb/measure.go
+++ b/influxdb/measure.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // AppendMeasure is a formatting routine to append the InflxDB line protocol

--- a/influxdb/measure_test.go
+++ b/influxdb/measure_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 var (

--- a/netstats/conn.go
+++ b/netstats/conn.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/segmentio/vpcinfo"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/netstats/conn_test.go
+++ b/netstats/conn_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestBaseConn(t *testing.T) {

--- a/netstats/handler.go
+++ b/netstats/handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // Handler is an interface that can be implemented by types that serve network

--- a/netstats/listener.go
+++ b/netstats/listener.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // NewListener returns a new net.Listener which uses the stats.DefaultEngine.

--- a/netstats/listener_test.go
+++ b/netstats/listener_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestListener(t *testing.T) {

--- a/otlp/go.mod
+++ b/otlp/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/stats/v4/otlp
+module github.com/segmentio/stats/v5/otlp
 
 go 1.19
 

--- a/otlp/handler.go
+++ b/otlp/handler.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )

--- a/otlp/measure.go
+++ b/otlp/measure.go
@@ -1,7 +1,7 @@
 package otlp
 
 import (
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )

--- a/otlp/metric.go
+++ b/otlp/metric.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 type metric struct {

--- a/otlp/otlp_test.go
+++ b/otlp/otlp_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )

--- a/procstats/collector_test.go
+++ b/procstats/collector_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestCollector(t *testing.T) {

--- a/procstats/delaystats.go
+++ b/procstats/delaystats.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // DelayMetrics is a metric collector that reports resource delays on processes.

--- a/procstats/delaystats_test.go
+++ b/procstats/delaystats_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/procstats"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/procstats"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestProcMetrics(t *testing.T) {

--- a/procstats/go.go
+++ b/procstats/go.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func init() {

--- a/procstats/go_test.go
+++ b/procstats/go_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestGoMetrics(t *testing.T) {

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // ProcMetrics is a metric collector that reports metrics on processes.

--- a/procstats/proc_linux.go
+++ b/procstats/proc_linux.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/segmentio/stats/v4/procstats/linux"
+	"github.com/segmentio/stats/v5/procstats/linux"
 
 	"golang.org/x/sys/unix"
 )

--- a/procstats/proc_test.go
+++ b/procstats/proc_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/statstest"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/statstest"
 )
 
 func TestProcMetrics(t *testing.T) {

--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 // Handler is a type that bridges the stats API to a prometheus-compatible HTTP

--- a/prometheus/handler_test.go
+++ b/prometheus/handler_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func TestAcceptEncoding(t *testing.T) {

--- a/prometheus/label.go
+++ b/prometheus/label.go
@@ -3,7 +3,7 @@ package prometheus
 import (
 	"github.com/segmentio/fasthash/jody"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 type label struct {

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -8,7 +8,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 type metricType int

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func TestUnsafeByteSliceToString(t *testing.T) {

--- a/statstest/handler.go
+++ b/statstest/handler.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 var (

--- a/veneur/client.go
+++ b/veneur/client.go
@@ -3,8 +3,8 @@ package veneur
 import (
 	"time"
 
-	"github.com/segmentio/stats/v4"
-	"github.com/segmentio/stats/v4/datadog"
+	"github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/datadog"
 )
 
 // Const Sink Configuration types.

--- a/veneur/client_test.go
+++ b/veneur/client_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/stats/v4"
+	"github.com/segmentio/stats/v5"
 )
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
Since we bumped the major version, we need to bump all of the imports as well to match.