### PR TITLE
debugstats: new package

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Daniel Fuentes <daniel.fuentes@segment.com> <daniel.richard.fuentes@gmail.com>
+Amir Abu Shareb <yields@icloud.com> Amir Abushareb
+Achille Roussel <achille.roussel@segment.com> Achille <achille@segment.com> 
+Achille Roussel <achille.roussel@segment.com> Achille Roussel <achille@segment.com> 
+Achille Roussel <achille.roussel@segment.com> Achille <achille.roussel@gmail.com>
+John Boggs <jboggs@twilio.com> <upsidedowntophat@gmail.com>
+Michael S. Fischer <michael.fischer@segment.com> <michael+github@dynamine.net>
+Ray Jenkins <ray@segment.com> <ray.jenkins@segment.com>
+Alan Braithwaite <alan@segment.com> <asbraithwaite@gmail.com>
+Hyonjee Joo <5000208+hjoo@users.noreply.github.com> <hyonjee.joo@segment.com>
+Julien Fabre <julien@segment.com> <ju.pryz@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,36 @@
+Achille Roussel <achille.roussel@segment.com>
+Alan Braithwaite <alan@segment.com>
+Amir Abu Shareb <yields@icloud.com>
+Bill Havanki <bhavanki@users.noreply.github.com>
+Clement Rey <cr.rey.clement@gmail.com>
+Colin <colinking@users.noreply.github.com>
+Collin Van Dyck <collin@segment.com>
+Daniel Fuentes <daniel.fuentes@segment.com>
+David Betts <wdbetts@gmail.com>
+David Scrobonia <dscrobonia@users.noreply.github.com>
+Dean Karn <Dean.Karn@gmail.com>
+Dominic Barnes <dominic@dbarnes.info>
+Erik Weathers <erikdw@gmail.com>
+Hyonjee Joo <5000208+hjoo@users.noreply.github.com>
+Jeremy Jackins <jeremyjackins@gmail.com>
+John Boggs <jboggs@twilio.com>
+Joseph Herlant <aerostitch@users.noreply.github.com>
+Julien Fabre <julien@segment.com>
+Kevin Burke <kevin.burke@segment.com>
+Kevin Gillette <kgillette@twilio.com>
+Matt Layher <mdlayher@gmail.com>
+Michael S. Fischer <michael.fischer@segment.com>
+Mike Nichols <nichols.mike.s@gmail.com>
+Prateek Srivastava <f2prateek@gmail.com>
+Ray Jenkins <ray@segment.com>
+Rick Branson <rick@diodeware.com>
+Rob McQueen <rob@segment.com>
+Rohit Garg <rohitgarg19@gmail.com>
+Thomas Meson <thomas@zen.ly>
+Tyson Mote <tyson@segment.com>
+Ulysse Carion <ulyssecarion@gmail.com>
+Vic Vijayakumar <needcaffeine@users.noreply.github.com>
+Yerden Zhumabekov <yerden.zhumabekov@gmail.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+noctarius aka Christoph Engelbert <me@noctarius.com>
+sungjujin <87332309+sungjujin@users.noreply.github.com>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,17 @@
 # History
 
+### v5.3.0 (December 19, 2024)
+
+- Add `debugstats` package that can easily print metrics to stdout.
+
+- Fix file handle leak in procstats in the DelayMetrics collector.
+
 ### v5.2.0
 
-
+- `go_version.value` and `stats_version.value` will be emitted the first
+time any metrics are sent from an Engine. Disable this behavior by setting
+`GoVersionReportingEnabled = false` in code, or setting environment variable
+`STATS_DISABLE_GO_VERSION_REPORTING=true`.
 
 ### v5.1.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+### v5.2.0
+
+
+
 ### v5.1.0
 
 Add support for publishing stats to Unix datagram sockets (UDS).

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,10 @@ lint:
 
 release:
 	go run github.com/kevinburke/bump_version@latest --tag-prefix=v minor version/version.go
+
+force: ;
+
+AUTHORS.txt: force
+	go run github.com/kevinburke/write_mailmap@latest > AUTHORS.txt
+
+authors: AUTHORS.txt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 go get github.com/segmentio/stats/v5
 ```
 
-Migration to v5
+Migration to v4/v5
 ---------------
 
 Version 4 of the stats package introduced a new way of producing metrics based
@@ -47,7 +47,7 @@ To avoid greatly increasing the complexity of the codebase some old APIs were
 removed in favor of this new approach, other were transformed to provide more
 flexibility and leverage new features.
 
-The stats package used to only support float values, metrics can now be of
+The stats package used to only support float values. Metrics can now be of
 various numeric types (see stats.MakeMeasure for a detailed description),
 therefore functions like `stats.Add` now accept an `interface{}` value instead
 of `float64`. `stats.ObserveDuration` was also removed since this new approach
@@ -176,6 +176,23 @@ func main() {
 }
 ```
 
+### Troubleshooting
+
+Use the `debugstats` package to print all stats to the console.
+
+```go
+handler := debugstats.Client{Dst: os.Stdout}
+engine := stats.NewEngine("engine-name", handler)
+engine.Incr("server.start")
+```
+
+You can use the `Grep` property to filter the printed metrics for only ones you
+care about:
+
+```go
+handler := debugstats.Client{Dst: os.Stdout, Grep: regexp.MustCompile("server.start")}
+```
+
 Monitoring
 ----------
 
@@ -300,7 +317,7 @@ func main() {
 ```
 
 You can also modify the default HTTP client to automatically get metrics for all
-packages using it, this is very convinient to get insights into dependencies.
+packages using it, this is very convenient to get insights into dependencies.
 
 ```go
 package main

--- a/debugstats/debugstats.go
+++ b/debugstats/debugstats.go
@@ -1,0 +1,119 @@
+// Package debugstats simplifies metric troubleshooting by sending metrics to
+// any io.Writer.
+//
+// By default, metrics will be printed to os.Stdout. Use the Dst and Grep fields
+// to customize the output as appropriate.
+package debugstats
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/segmentio/stats/v5"
+)
+
+// Client will print out received metrics. If Dst is nil, metrics will be
+// printed to stdout, otherwise they will be printed to Dst.
+//
+// You can optionally provide a Grep regexp to limit printed metrics to ones
+// matching the regular expression.
+type Client struct {
+	Dst  io.Writer
+	Grep *regexp.Regexp
+}
+
+func (c *Client) Write(p []byte) (int, error) {
+	if c.Dst == nil {
+		return os.Stdout.Write(p)
+	}
+	return c.Dst.Write(p)
+}
+
+func normalizeFloat(f float64) float64 {
+	switch {
+	case math.IsNaN(f):
+		return 0.0
+	case math.IsInf(f, +1):
+		return +math.MaxFloat64
+	case math.IsInf(f, -1):
+		return -math.MaxFloat64
+	default:
+		return f
+	}
+}
+
+func appendMeasure(b []byte, m stats.Measure) []byte {
+	for _, field := range m.Fields {
+		b = append(b, m.Name...)
+		if len(field.Name) != 0 {
+			b = append(b, '.')
+			b = append(b, field.Name...)
+		}
+		b = append(b, ':')
+
+		switch v := field.Value; v.Type() {
+		case stats.Bool:
+			if v.Bool() {
+				b = append(b, '1')
+			} else {
+				b = append(b, '0')
+			}
+		case stats.Int:
+			b = strconv.AppendInt(b, v.Int(), 10)
+		case stats.Uint:
+			b = strconv.AppendUint(b, v.Uint(), 10)
+		case stats.Float:
+			b = strconv.AppendFloat(b, normalizeFloat(v.Float()), 'g', -1, 64)
+		case stats.Duration:
+			b = strconv.AppendFloat(b, v.Duration().Seconds(), 'g', -1, 64)
+		default:
+			b = append(b, '0')
+		}
+
+		switch field.Type() {
+		case stats.Counter:
+			b = append(b, '|', 'c')
+		case stats.Gauge:
+			b = append(b, '|', 'g')
+		default:
+			b = append(b, '|', 'd')
+		}
+
+		if n := len(m.Tags); n != 0 {
+			b = append(b, '|', '#')
+
+			for i, t := range m.Tags {
+				if i != 0 {
+					b = append(b, ',')
+				}
+				b = append(b, t.Name...)
+				b = append(b, ':')
+				b = append(b, t.Value...)
+			}
+		}
+
+		b = append(b, '\n')
+	}
+
+	return b
+}
+
+func (c *Client) HandleMeasures(t time.Time, measures ...stats.Measure) {
+	for i := range measures {
+		m := &measures[i]
+
+		// Process and output the measure
+		out := make([]byte, 0)
+		out = appendMeasure(out, *m)
+		if c.Grep != nil && !c.Grep.Match(out) {
+			continue // Skip this measure
+		}
+
+		fmt.Fprintf(c, "%s %s", t.Format(time.RFC3339), out)
+	}
+}

--- a/debugstats/debugstats_test.go
+++ b/debugstats/debugstats_test.go
@@ -1,0 +1,48 @@
+package debugstats
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/segmentio/stats/v5"
+)
+
+func TestStdout(t *testing.T) {
+	var buf bytes.Buffer
+	s := &Client{Dst: &buf}
+	stats.Register(s)
+	stats.Set("blah", 7)
+	stats.Observe("compression_ratio", 0.3, stats.T("file_size_bucket", "bucket_name"), stats.T("algorithm", "jwt256"))
+	bufstr := buf.String()
+	want := "debugstats.test.compression_ratio:0.3|d|#algorithm:jwt256,file_size_bucket:bucket_name\n"
+	if !strings.HasSuffix(bufstr, want) {
+		t.Errorf("debugstats: got %v want %v", bufstr, want)
+	}
+}
+
+func TestStdoutGrepMatch(t *testing.T) {
+	var buf bytes.Buffer
+	s := &Client{
+		Dst:  &buf,
+		Grep: regexp.MustCompile(`compression_ratio`),
+	}
+	eng := stats.NewEngine("prefix", s)
+
+	// Send measures that match and don't match the Grep pattern
+	eng.Set("compression_ratio", 0.3)
+	eng.Set("other_metric", 42)
+	eng.Flush()
+
+	bufstr := buf.String()
+
+	// Check that only the matching measure is output
+	if !strings.Contains(bufstr, "compression_ratio:0.3") {
+		t.Errorf("debugstats: expected output to contain 'compression_ratio:0.3', but it did not. Output: %s", bufstr)
+	}
+
+	if strings.Contains(bufstr, "other_metric") {
+		t.Errorf("debugstats: expected output not to contain 'other_metric', but it did. Output: %s", bufstr)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,20 @@
+package stats_test
+
+import (
+	"os"
+
+	stats "github.com/segmentio/stats/v5"
+	"github.com/segmentio/stats/v5/debugstats"
+)
+
+func Example() {
+	handler := &debugstats.Client{Dst: os.Stdout}
+	engine := stats.NewEngine("engine-name", handler)
+	// Will print:
+	//
+	// 2024-12-18T14:53:57-08:00 engine-name.server.start:1|c
+	//
+	// to the console.
+	engine.Incr("server.start")
+	engine.Flush()
+}

--- a/httpstats/handler_test.go
+++ b/httpstats/handler_test.go
@@ -31,14 +31,15 @@ func TestHandler(t *testing.T) {
 	io.ReadAll(res.Body)
 	res.Body.Close()
 
+	e.Flush()
 	measures := h.Measures()
 
 	if len(measures) == 0 {
 		t.Error("no measures reported by http handler")
 	}
 
+	tagSeen := false
 	for _, m := range measures {
-		tagSeen := false
 		for _, tag := range m.Tags {
 			if tag.Name == "bucket" {
 				switch tag.Value {
@@ -54,9 +55,9 @@ func TestHandler(t *testing.T) {
 				}
 			}
 		}
-		if !tagSeen {
-			t.Errorf("did not see user-added tag for wrapped request. tags: %#v\n%#v", m, m.Tags)
-		}
+	}
+	if !tagSeen {
+		t.Errorf("did not see user-added tag for wrapped request. measures: %#v", measures)
 	}
 
 	for _, m := range measures {

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -28,7 +28,7 @@ type HTTPClient struct {
 
 func NewHTTPClient(endpoint string) *HTTPClient {
 	return &HTTPClient{
-		//TODO: add sane default timeout configuration.
+		// TODO: add sane default timeout configuration.
 		client:   http.DefaultClient,
 		endpoint: endpoint,
 	}

--- a/otlp/handler.go
+++ b/otlp/handler.go
@@ -51,9 +51,7 @@ type Handler struct {
 	metrics map[uint64]*list.Element
 }
 
-var (
-	hashseed = maphash.MakeSeed()
-)
+var hashseed = maphash.MakeSeed()
 
 // NewHandler return an instance of Handler with the default client,
 // flush interval and in-memory metrics limit.
@@ -163,7 +161,7 @@ func (h *Handler) flush() error {
 		return nil
 	}
 
-	//FIXME how big can a metrics service request be ? need pagination ?
+	// FIXME how big can a metrics service request be ? need pagination ?
 	request := &colmetricpb.ExportMetricsServiceRequest{
 		ResourceMetrics: []*metricpb.ResourceMetrics{
 			{

--- a/procstats/proc.go
+++ b/procstats/proc.go
@@ -40,7 +40,7 @@ type procCPU struct {
 
 type procMemory struct {
 	// Memory
-	available uint64 `metric:"available.bytes" type:"gauge"` // amound of RAM available to the process
+	available uint64 `metric:"available.bytes" type:"gauge"` // amount of RAM available to the process
 	size      uint64 `metric:"total.bytes"     type:"gauge"` // total program memory (including virtual mappings)
 
 	resident struct { // resident set size


### PR DESCRIPTION
This makes it easier to troubleshoot problems with the metrics pipeline, by visualizing what metrics are emitted.

Fix the existing go_version and stats_version reporter to ensure that they work even if metrics are reported with ReportAt instead of Incr, Set, Observe etc.