### PR TITLE
datadog: correctly pass through buffer size

### DIFF
--- a/datadog/client.go
+++ b/datadog/client.go
@@ -125,6 +125,7 @@ func NewClientWith(config ClientConfig) *Client {
 
 	c.bufferSize = newBufSize
 	c.buffer.Serializer = &c.serializer
+	c.buffer.BufferSize = newBufSize
 	c.serializer.conn = w
 	log.Printf("stats/datadog: sending metrics with a buffer of size %d B", newBufSize)
 	return c

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -38,6 +38,16 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClientSetsBothBufferSizes(t *testing.T) {
+	c := NewClientWith(ClientConfig{BufferSize: 12345})
+	if c.bufferSize != 12345 {
+		t.Errorf("expected buffer size to be 12345, got %d", c.bufferSize)
+	}
+	if c.buffer.BufferSize != 12345 {
+		t.Errorf("expected buffer.BufferSize to be 12345, got %d", c.buffer.BufferSize)
+	}
+}
+
 func TestClientWithDistributionPrefixes(t *testing.T) {
 	client := NewClientWith(ClientConfig{
 		Address:              DefaultAddress,


### PR DESCRIPTION
Commit https://github.com/segmentio/stats/commit/251d359fb3a73d89b45ab3c4029d7f98994151b4 introduced a
regression that slowed stat write benchmarks by 2.5x on Linux and 1.5x
on Mac. The regression was caused by small writes causing contention
for a shared file descriptor.

This error was introduced in https://github.com/segmentio/stats/pull/169 - if you scroll to datadog/client.go
in that pull request, you can see how it happens, the buffer should be
set on both the datadog serializer and the underlying buffer.Buffer,
but was only set on one of those.

Unfortunate error, and I will try to perform more benchmark testing
going forward.