### PR TITLE
Fix deadlock in metrics

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -226,11 +226,14 @@ func (entry *metricEntry) cleanup(exp time.Time, empty func()) {
 		}
 	}
 
-	if len(entry.states) == 0 {
-		empty()
-	}
-
+	// remember whether we emptied out all states _while_ holding the lock
+	shouldDelete := (len(entry.states) == 0)
 	entry.mutex.Unlock()
+
+	// now call back into store (taking store.mutex) only after releasing entry.mutex
+	if shouldDelete {
+       empty()
+    }
 }
 
 type metricState struct {


### PR DESCRIPTION
In the current implementation, `metricEntry.cleanup` does all of its work (including potentially calling provided `empty` callback) while still holding `entry.mutex`. The `empty` callback then grabs `store.mutex.Lock()` to delete the entry from the global map. Meanwhile, `metricStore.collect` holds `store.mutex.RLock()` and then tries to acquire `entry.mutex.RLock()`. In worst‐case interleaving, one goroutine holds the entry lock waiting on the store lock, while another holds the store read-lock waiting on the entry lock, leading to a circular wait and deadlock.

The patch simply breaks that inversion by splitting the cleanup into two phases: under entry.mutex, you expire states and record whether the entry is empty; you then release entry.mutex and only after that unlock invoke empty(), which takes store.mutex. This guarantees you never hold both locks at once, restores a consistent lock‐acquisition order, and eliminates the deadlock.

The included test is just to demonstrate the deadlock exists. It may be too slow to keep, but I leave that up to the project.