### PR TITLE
.github: build CI on all branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,7 @@
 name: Test
 "on":
   - pull_request
+  - push
 
 jobs:
   test:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,6 @@ name: golangci-lint
   push:
     tags:
       - v*
-    branches: [main]
     paths:
       - '**.go'
       - .golangci.yml


### PR DESCRIPTION
We don't need to be thrifty with CI builds, there aren't a lot of them.