### PR TITLE
datadog: maximum length checks name length, not buffer length

### DIFF
--- a/datadog/serializer_test.go
+++ b/datadog/serializer_test.go
@@ -306,11 +306,9 @@ func TestAppendSanitizedMetricName(t *testing.T) {
 
 		// over-long → truncated (but preserve prefix if it fits)
 		{"", long, strings.Repeat("x", maxLen)},
-		{"short_", long, "short_" + strings.Repeat("x", maxLen-6)}, // 6 = len("short_")
+		{"short_", long, "short_" + strings.Repeat("x", maxLen)}, // 6 = len("short_")
 
-		// Test edge case where prefix + content exceeds maxLen
-		{strings.Repeat("x", 240), "content.data.here", strings.Repeat("x", 240) + "content.da"}, // Should truncate at maxLen=250
-
+		{strings.Repeat("x", 240), "content.data.here", strings.Repeat("x", 240) + "content.data.here"},
 	}
 
 	for _, c := range cases {
@@ -323,17 +321,12 @@ func TestAppendSanitizedMetricName(t *testing.T) {
 		got := string(buf)
 
 		if got != c.want {
-			t.Fatalf("prefix=%q in=%q  want=%q  got=%q", c.prefix, c.in, c.want, got)
+			t.Fatalf("prefix=%q in=%q want=%q (len %v) got=%q (len %v)", c.prefix, c.in, c.want, len(c.want), got, len(got))
 		}
 
 		// Verify prefix is preserved
 		if len(c.prefix) > 0 && !strings.HasPrefix(got, c.prefix) {
 			t.Errorf("prefix %q not preserved in result %q", c.prefix, got)
-		}
-
-		// Verify length constraints
-		if len(buf) > maxLen {
-			t.Errorf("result %q length=%d exceeds maxLen=%d", got, len(buf), maxLen)
 		}
 
 		// Verify we only modified the buffer from the original length onward


### PR DESCRIPTION
Previously we applied the `maxLen` constraint to the length of the buffer, not to the length of the metric or tag name, which led to truncation after writing a single character, once the buffer exceeded 250 characters. This is incorrect.

Fix the behavior of the code and also the tests (which inadvertently checked the wrong thing).