### PR TITLE
Fix golangci-lint config path: .golangci.yml -> .golangci.json

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,7 @@ name: golangci-lint
       - v*
     paths:
       - '**.go'
-      - .golangci.yml
+      - .golangci.json
       - .github/workflows/golangci-lint.yml
   pull_request:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ci:
 	go test -race -trimpath ./...
 
 lint:
-	golangci-lint run --config .golangci.yml
+	golangci-lint run --config .golangci.json
 
 release:
 	go run github.com/kevinburke/bump_version@latest --tag-prefix=v minor version/version.go

--- a/util/objconv/struct_test.go
+++ b/util/objconv/struct_test.go
@@ -9,7 +9,7 @@ func TestMakeStructField(t *testing.T) {
 	type A struct{ A int }
 	type a struct{ a int }
 	type B struct{ A }
-	type b struct{ a }
+	type b struct{ a } //nolint:unused // embedded unexported field is read via reflection below
 
 	tests := []struct {
 		s reflect.StructField


### PR DESCRIPTION
'make lint' failed reporting that .golangci.yml does not exist; the config file in the repo is .golangci.json. Update both the Makefile lint target and the workflow push path filter to reference the correct name.