### PR TITLE
ci: target ubuntu-latest-large runner label

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,15 +12,15 @@ jobs:
           - 'oldstable'
           - 'stable'
         label:
-          - ubuntu-latest
+          - ubuntu-latest-large
 
     runs-on: ${{ matrix.label }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Go (${{ matrix.go }})
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,15 +16,19 @@ name: golangci-lint
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: '>=1.24'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install golangci-lint
+        # https://github.com/golangci/golangci-lint/tags
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.1.6
+        run: golangci-lint run


### PR DESCRIPTION
## Summary
- Fixes CI on the `cstj/migrate-runs-on-twilio-runners` migration (PR #223): both `go.yml`'s test matrix and `golangci-lint.yml` now target `ubuntu-latest-large`, per guidance from Charlotte St. John.
- Keeps the SHA-pinned action refs from the original migration PR.

## Context
`segmentio/stats` is a public repo hitting the "auto/bot PRs break" collateral damage described in PEA-901 - jobs targeting `ubuntu-latest` were hanging indefinitely (never picked up a runner) rather than failing fast, and `ubuntu-latest-large` initially startup-failed. Confirmed working after this change: https://github.com/segmentio/stats/actions/runs/30404362365

## Test plan
- [x] `Test` workflow green on push (both oldstable/stable) - run 30404362365
- [ ] `golangci-lint` triggers on this PR - confirm green