### PR TITLE
ci: limit fuzz test to 2 parallel workers to avoid CI flakiness

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
         run: go test -trimpath -race ./...
 
       - name: Run Fuzz Tests
-        run: go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=5s ./datadog
+        run: go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=5s -parallel=2 ./datadog


### PR DESCRIPTION
## Summary
- `go test -fuzz` spawns one worker subprocess per CPU. The Go toolchain enforces a hardcoded 1s response deadline per worker RPC; on a contended runner a worker can miss it, failing the whole run with `context deadline exceeded` unrelated to the sanitizer code being tested (seen in https://github.com/segmentio/stats/actions/runs/30407686004/job/90436700862).
- Cap `-parallel=2` on the fuzz step to reduce CPU contention between workers and avoid tripping that deadline.

## Test plan
- [x] Pushed to `fix-fuzz-ci-timeout` and confirmed CI is green (both `stable` and `oldstable` matrix jobs, including the Run Fuzz Tests step): https://github.com/segmentio/stats/actions/runs/30433954592

🤖 Generated with [Claude Code](https://claude.com/claude-code)