### PR TITLE
Release v5.10.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-### v5.10.0 (Unreleased)
+### v5.10.0 (July 30, 2026)
 
 **The minimum supported Go version is now 1.25.** The `otlp` package, previously
 its own nested module, has been folded back into `github.com/segmentio/stats/v5`

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-const Version = "5.9.0"
+const Version = "5.10.0"
 
 var (
 	vsnOnce sync.Once


### PR DESCRIPTION
## Summary
- Mark the v5.10.0 HISTORY.md entry as released (was "Unreleased")
- Bump `version/version.go` from 5.9.0 to 5.10.0

This is the release for the otlp-module-fold changes already on main (see the `v5.10.0` HISTORY.md section added in b0ca572).

## Test plan
- [ ] CI passes
- [ ] After merge, tag the resulting main commit as `v5.10.0` (signed) and push the tag