### PR TITLE
ci: use a count-based fuzztime limit to dodge a Go toolchain race

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
         run: go test -trimpath -race ./...
 
       - name: Run Fuzz Tests
-        run: go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=5s -parallel=2 ./datadog
+        run: go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=1000000x -parallel=2 ./datadog


### PR DESCRIPTION
## Summary
- The `Run Fuzz Tests` CI step (`go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=5s -parallel=2 ./datadog`) intermittently fails with a bare `context deadline exceeded` and no crasher input.
- This is a known, currently-unfixed race in Go's `internal/fuzz` package ([golang/go#75804](https://github.com/golang/go/issues/75804)): the context deadline used to stop workers at the end of `-fuzztime` can leak past the code meant to suppress it as a normal stop signal.
- Confirmed this against the exact CI failure (run [30568362844](https://github.com/segmentio/stats/actions/runs/30568362844), commit `888a447`, `stable` Go leg only, go1.26.5) — matches the upstream repro output byte-for-byte, and reproduces regardless of `-fuzztime` duration per the Go team's own testing (seen from 3s to 10+ minutes). The fix (CL 804900) only merged into `release-branch.go1.27` on 2026-07-23 and isn't in any released stable/oldstable toolchain yet.
- Switches to a count-based limit (`-fuzztime=1000000x`) instead of a wall-clock duration, which avoids the `context.WithTimeout` deadline path entirely and sidesteps the race rather than gambling on duration.

## Test plan
- [x] Ran `go test -fuzz=FuzzAppendSanitizedMetricName -fuzztime=1000000x -parallel=2 ./datadog` locally — stops precisely at `execs: 1000000`, passes cleanly (~14s).
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)