### PR TITLE
docs: fix Prometheus README snippet, remove nonexistent NewHandler()

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,13 @@ import (
     "github.com/segmentio/stats/v5/prometheus"
 )
 
-handler := prometheus.NewHandler()
-stats.Register(handler)
-http.Handle("/metrics", handler)
+stats.Register(prometheus.DefaultHandler)
+http.Handle("/metrics", prometheus.DefaultHandler)
 ```
+
+`Handler` has no `NewHandler` constructor; `DefaultHandler` is a ready-to-use zero-config
+instance. Construct your own `&prometheus.Handler{}` literal instead if you need to set
+`TrimPrefix`, `MetricTimeout`, or `Buckets`.
 
 ### InfluxDB
 


### PR DESCRIPTION
## Summary
- The Prometheus section's usage snippet calls `prometheus.NewHandler()`, which doesn't exist and never has (checked back through v4.7.2). `Handler` is a plain struct with no constructor.
- Root cause: this section was added in 7e7070d alongside the OTLP exporter and looks like a copy-paste from `otlp.NewHandler`, a real constructor on that subpackage.
- Fixed to use the package's own zero-config `DefaultHandler`, with a note that a `&prometheus.Handler{}` literal works too if you need to set `TrimPrefix`/`MetricTimeout`/`Buckets`.

## Test plan
- [x] Confirmed `DefaultHandler` and the `Handler` struct/fields exist as described, via `handler.go` and `handler_test.go`
- [x] Docs-only change, no code affected